### PR TITLE
Flatten epsilon targets during arena NFA merges

### DIFF
--- a/docs/bench-baselines.md
+++ b/docs/bench-baselines.md
@@ -1,0 +1,50 @@
+# Benchmark Baselines
+
+Recorded on M3 Max, commit 78cac82.
+
+## matching bench (cargo bench --bench matching)
+
+| Benchmark | Time (ns) |
+|-----------|-----------|
+| exact_match | 127 |
+| nested_match | 177 |
+| regex_match | 100 |
+| has_matches_early_exit | 208 |
+| flatten_context_fields | ~156 |
+| shellstyle_26_patterns | 513 |
+
+## 10k benchmarks (cargo bench --bench matching -- "10k_")
+
+| Benchmark | Time (ns) |
+|-----------|-----------|
+| 10k_patterns_1_match | 179 |
+| 10k_patterns_no_match | 73 |
+| 10k_diverse_patterns_1_match | 152 |
+| 10k_mixed_exact_match | 172 |
+| 10k_mixed_prefix_match | 171 |
+| 10k_mixed_numeric_match | 179 |
+
+## Optimization Log
+
+### Flatten Epsilon Targets (Go PR #486) - one-level
+
+**Change:** During arena NFA merges, inline epsilon targets of epsilon-only
+splice states one level deep, reducing nesting from repeated merges.
+
+**Approach tested:**
+1. Full recursive flatten: -6% on small patterns, but +5-9% REGRESSION on 10k
+   patterns due to huge SmallVec spill and poor cache locality.
+2. One-level flatten (shipped): -3% to -7% across ALL benchmarks. No regressions.
+
+**Clean A/B results (criterion, same session):**
+
+| Benchmark | Before | After | Change |
+|-----------|--------|-------|--------|
+| exact_match | 127 ns | 121 ns | **-3.5%** |
+| nested_match | 177 ns | 171 ns | **-5.6%** |
+| shellstyle_26 | 513 ns | 489 ns | **-6.6%** |
+| 10k_1_match | 179 ns | 167 ns | **-6.1%** |
+| 10k_no_match | 73 ns | 71 ns | **-3.5%** |
+| 10k_exact | 172 ns | 163 ns | **-5.3%** |
+| 10k_prefix | 171 ns | 161 ns | **-4.9%** |
+| 10k_numeric | 179 ns | 175 ns | **-3.5%** |

--- a/docs/go-sync-status.md
+++ b/docs/go-sync-status.md
@@ -61,6 +61,20 @@ Checked: Feb 2026. ~20 non-merge commits since `e3d13cd`, all optimizations (no 
 
 **Rust status:** N/A. Rust's regexp implementation doesn't have this parameter. Design lesson: don't expose parameters that are always the same value.
 
+## Porting Tracker
+
+Investigate each Go optimization empirically - one per session. Measure before/after.
+
+| # | Optimization | Initial Assessment | Empirical Result | Session |
+|---|---|---|---|---|
+| 1 | Flatten Epsilon Targets (#486) | PORT CANDIDATE | PORTED (one-level), -3% to -7% | Feb 2026 |
+| 2 | Epsilon Closure Refactoring (#482) | SKIP (arena already has SparseSet) | | |
+| 3 | Cache startState (#490) | SKIP (marginal in Rust) | | |
+| 4 | SkinnyRuneTree (#483) | DEFER (no Unicode prop automata) | | |
+| 5 | forField Removal | N/A (different design) | | |
+
+---
+
 ## Behavioral Differences from Go
 
 1. `{"anything-but": "foo"}` - Rust accepts single string, Go requires array

--- a/src/automaton/arena.rs
+++ b/src/automaton/arena.rs
@@ -1041,6 +1041,50 @@ pub fn merge_arena_nfas(
     (new_arena, start)
 }
 
+/// Check if a state is an "epsilon-only" splice state created during merges.
+///
+/// These synthetic states only serve to branch into multiple epsilon targets,
+/// with no byte transitions, spinout behavior, or field transitions.
+/// Mirrors Go's `smallTable.isEpsilonOnly()`, with additional guards for
+/// Rust's spinout and field_transition fields.
+fn is_epsilon_only_state(arena: &StateArena, state_id: StateId) -> bool {
+    if state_id.is_none() {
+        return false;
+    }
+    let state = &arena[state_id];
+    !state.table.epsilons.is_empty()
+        && state.table.ceilings.len() == 1
+        && state.table.spinout.is_none()
+        && state.field_transitions.is_empty()
+}
+
+/// Flatten immediate epsilon-only splice states one level deep.
+///
+/// When merging creates splice states, repeated merges can nest them:
+///   splice2 -> [splice1 -> [A, B], C]  (depth 2)
+/// This function inlines one level of splice targets:
+///   splice2 -> [A, B, C]  (depth reduced by 1)
+///
+/// Only flattens one level to avoid creating huge epsilon lists for
+/// high-pattern-count scenarios (10k+ patterns). Mirrors the intent of
+/// Go's `flattenEpsilonTargets()` from PR #486, adapted for Rust's
+/// arena architecture where large inline lists hurt cache performance.
+fn flatten_epsilon_targets(arena: &StateArena, states: &[StateId]) -> SmallVec<[StateId; 2]> {
+    let mut targets = SmallVec::new();
+
+    for &state_id in states {
+        if !state_id.is_none() && is_epsilon_only_state(arena, state_id) {
+            // Splice state - inline its direct epsilon targets (one level)
+            for &eps_id in &arena[state_id].table.epsilons {
+                targets.push(eps_id);
+            }
+        } else {
+            targets.push(state_id);
+        }
+    }
+    targets
+}
+
 /// Check if a state is a "spinout state" (has spinout marker and exactly 1 epsilon).
 ///
 /// Spinout states are used for wildcard patterns. The convention is:
@@ -1148,6 +1192,8 @@ fn merge_arena_nfa_states_recursive(
     }
 
     // Case 2: Either has epsilons (but not both spinouts) - create splice
+    // Flatten epsilon targets to prevent deep nesting from repeated merges.
+    // (Mirrors Go PR #486: flattenEpsilonTargets)
     if s1_has_epsilons || s2_has_epsilons {
         let mut clone_map1: std::collections::HashMap<u32, StateId> =
             std::collections::HashMap::new();
@@ -1156,10 +1202,14 @@ fn merge_arena_nfa_states_recursive(
         let cloned1 = clone_state_into_arena(arena1, state1, new_arena, &mut clone_map1);
         let cloned2 = clone_state_into_arena(arena2, state2, new_arena, &mut clone_map2);
 
+        // Flatten: if cloned states are themselves epsilon-only splices,
+        // collect their real targets directly instead of nesting splices.
+        let epsilons = flatten_epsilon_targets(new_arena, &[cloned1, cloned2]);
+
         new_arena[new_id].table = ArenaSmallTable {
             ceilings: smallvec![BYTE_CEILING as u8],
             steps: smallvec![StateId::NONE],
-            epsilons: smallvec![cloned1, cloned2],
+            epsilons,
             spinout: StateId::NONE,
             accel: None,
             default: StateId::NONE,
@@ -4357,6 +4407,47 @@ mod nfa_merge_tests {
         assert!(
             merged_start3.is_none(),
             "Merging two empty arenas should return NONE"
+        );
+    }
+
+    /// Verify that repeated merges flatten splice states instead of nesting them.
+    ///
+    /// Without flattening, merging A+B+C+D creates:
+    ///   splice3 -> [splice2 -> [splice1 -> [A, B], C], D]  (depth 3)
+    /// With flattening:
+    ///   splice3 -> [A, B, C, D]  (depth 1)
+    #[test]
+    fn test_flatten_epsilon_targets_on_repeated_merge() {
+        let fm = Arc::new(FieldMatcher::new());
+
+        // Build 4 separate single-value arenas
+        let (a1, s1) = make_epsilon_alternation_arena(&[b"a"], fm.clone());
+        let (a2, s2) = make_epsilon_alternation_arena(&[b"b"], fm.clone());
+        let (a3, s3) = make_epsilon_alternation_arena(&[b"c"], fm.clone());
+        let (a4, s4) = make_epsilon_alternation_arena(&[b"d"], fm.clone());
+
+        // Merge them one by one (simulates adding patterns sequentially)
+        let (m12, s12) = merge_arena_nfas(&a1, s1, &a2, s2);
+        let (m123, s123) = merge_arena_nfas(&m12, s12, &a3, s3);
+        let (m1234, s1234) = merge_arena_nfas(&m123, s123, &a4, s4);
+
+        // All 4 values should still match
+        assert!(matches_value(&m1234, s1234, b"a"), "should match 'a'");
+        assert!(matches_value(&m1234, s1234, b"b"), "should match 'b'");
+        assert!(matches_value(&m1234, s1234, b"c"), "should match 'c'");
+        assert!(matches_value(&m1234, s1234, b"d"), "should match 'd'");
+        assert!(!matches_value(&m1234, s1234, b"e"), "should not match 'e'");
+
+        // Verify flattening: the start state's epsilons should point to
+        // real states (not nested splice states). With flattening, the
+        // start state should have more direct epsilon targets than 2.
+        let start_state = &m1234[s1234];
+        let eps_count = start_state.table.epsilons.len();
+        // Without flattening: always 2 epsilons (splice -> [prev_merge, new])
+        // With flattening: should be > 2 (all real states flattened)
+        assert!(
+            eps_count > 2,
+            "Flattening should produce > 2 direct epsilon targets, got {eps_count}"
         );
     }
 }


### PR DESCRIPTION
## Summary

- Port of [Go quamina PR #486](https://github.com/timbray/quamina/pull/486) (`flattenEpsilonTargets`), adapted for Rust's arena architecture
- During NFA merges, inline epsilon-only splice state targets one level deep
- Prevents accumulation of nested splice chains from repeated merges
- Adds `is_epsilon_only_state` and `flatten_epsilon_targets` helpers
- New test verifying flattening behavior on 4-way repeated merge

## Key design decision: one-level vs full recursive

Go's version recursively flattens all splice chains. We tested both:

| Approach | Small patterns | 10k patterns |
|----------|---------------|-------------|
| Full recursive | -6% to -10% | **+5% to +9% regression** |
| One-level (shipped) | -3% to -7% | **-3% to -6% improvement** |

Full recursive creates huge `SmallVec<[StateId; 2]>` epsilon lists (10k entries
spilling to heap) with poor cache locality. One-level limits growth while still
removing the immediate nesting from each merge step.

## Benchmark results (criterion A/B, M3 Max)

| Benchmark | Before | After | Change |
|-----------|--------|-------|--------|
| exact_match | 127 ns | 121 ns | -3.5% |
| nested_match | 177 ns | 171 ns | -5.6% |
| shellstyle_26 | 513 ns | 489 ns | -6.6% |
| 10k_patterns_1_match | 179 ns | 167 ns | -6.1% |
| 10k_mixed_exact | 172 ns | 163 ns | -5.3% |
| 10k_mixed_prefix | 171 ns | 161 ns | -4.9% |
| 10k_mixed_numeric | 179 ns | 175 ns | -3.5% |

No regressions. 430 tests pass (1 new).

## Spinout guard

Epsilon-only detection excludes states with `spinout != NONE` or non-empty
`field_transitions`, preventing wildcard/shellstyle spinout states from
being incorrectly flattened (caught by existing tests during development).

🤖 Generated with [Claude Code](https://claude.com/claude-code)