### PR TITLE
Strict clippy: numeric casts and macro fixes

### DIFF
--- a/.cargo-husky/hooks/pre-commit
+++ b/.cargo-husky/hooks/pre-commit
@@ -16,8 +16,8 @@ TEST_OUTPUT=$(cargo test --lib -- --skip stress --skip citylots --skip regexp_va
 }
 echo "$TEST_OUTPUT" | grep -E '^test result:'
 
-echo '+cargo clippy -- -D warnings'
-cargo clippy -- -D warnings
+echo '+cargo clippy --all-targets --all-features -- -D warnings'
+cargo clippy --all-targets --all-features -- -D warnings
 
 echo '+cargo fmt -- --check'
 cargo fmt -- --check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,13 +87,3 @@ missing_fields_in_debug = "allow"
 manual_let_else = "allow"
 assigning_clones = "allow"
 used_underscore_binding = "allow"
-
-# Nursery lints (selectively enabled/configured)
-use_self = "warn"
-derive_partial_eq_without_eq = "warn"
-redundant_clone = "warn"
-unused_peekable = "warn"
-or_fun_call = "warn"
-branches_sharing_code = "warn"
-equatable_if_let = "warn"
-disallowed_types = "warn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,12 +65,10 @@ nursery = { level = "warn", priority = -1 }
 perf = { level = "warn", priority = -1 }
 transmute_ptr_to_ptr = "warn"
 
-# Keep allows for lints that require massive structural/doc rewrites or conflict with performance
+# Remaining allows are for lints that conflict with performance choices
+# (inline-always on hot paths) or stylistic preferences we've consciously
+# kept (literal grouping, doc-comment markdown, etc.).
 inline_always = "allow"
-cast_possible_truncation = "allow"
-cast_possible_wrap = "allow"
-cast_precision_loss = "allow"
-cast_sign_loss = "allow"
 doc_markdown = "allow"
 unreadable_literal = "allow"
 option_if_let_else = "allow"
@@ -89,7 +87,6 @@ missing_fields_in_debug = "allow"
 manual_let_else = "allow"
 assigning_clones = "allow"
 used_underscore_binding = "allow"
-string_lit_as_bytes = "allow"
 
 # Nursery lints (selectively enabled/configured)
 use_self = "warn"

--- a/benches/memory.rs
+++ b/benches/memory.rs
@@ -36,9 +36,11 @@ impl MemoryStats {
         let stats = dhat::HeapStats::get();
         Self {
             name: name.to_string(),
-            total_bytes: stats.total_bytes as usize,
+            total_bytes: usize::try_from(stats.total_bytes)
+                .expect("dhat total_bytes fits in usize on this target"),
             max_bytes: stats.max_bytes,
-            total_allocs: stats.total_blocks as usize,
+            total_allocs: usize::try_from(stats.total_blocks)
+                .expect("dhat total_blocks fits in usize on this target"),
             max_allocs: stats.max_blocks,
         }
     }

--- a/examples/profile_budget_tuning.rs
+++ b/examples/profile_budget_tuning.rs
@@ -69,7 +69,10 @@ fn bench<F: FnMut()>(mut f: F) -> (u64, u64) {
         for _ in 0..iters {
             f();
         }
-        *s = t.elapsed().as_nanos() as u64 / iters;
+        // ns/iter, computed in u128 to avoid u128→u64 truncation, then
+        // narrowed back via try_from once we know the value is small.
+        let ns_per_iter = t.elapsed().as_nanos() / u128::from(iters);
+        *s = u64::try_from(ns_per_iter).expect("per-iter ns easily fits in u64");
     }
     let min = *samples.iter().min().unwrap();
     let max = *samples.iter().max().unwrap();
@@ -78,9 +81,11 @@ fn bench<F: FnMut()>(mut f: F) -> (u64, u64) {
 
 /// Format a `(min, max)` pair.  Flag with `!` when jitter exceeds 10%.
 fn fmt_ns(min: u64, max: u64) -> String {
-    let jitter = max as f64 / min as f64;
-    if jitter > 1.10 {
-        format!("{}ns!({:.0}%)", min, (jitter - 1.0) * 100.0)
+    // Integer percent: (max - min) * 100 / min. `min` is non-zero in
+    // practice; guard with `.max(1)` so divide-by-zero never panics.
+    let jitter_pct = max.saturating_sub(min).saturating_mul(100) / min.max(1);
+    if jitter_pct > 10 {
+        format!("{min}ns!({jitter_pct}%)")
     } else {
         format!("{min}ns")
     }
@@ -327,12 +332,16 @@ fn section1_tier_comparison() {
                     );
                 }
             });
+            // Speedup as integer tenths (e.g. "5.4x") computed without f64.
+            // Guard against divide-by-zero when DFA timing rounds to 0ns.
+            let speedup_tenths = nfa_match_min.saturating_mul(10) / dfa_match_min.max(1);
             println!(
-                "  EagerDFA build: {:>12}  match(warm): {:>14}  mem: {:>3} KB  ({:.1}x faster than NFA)",
+                "  EagerDFA build: {:>12}  match(warm): {:>14}  mem: {:>3} KB  ({}.{}x faster than NFA)",
                 fmt_ns(dfa_build_min, dfa_build_max),
                 fmt_ns(dfa_match_min, dfa_match_max),
                 dfa_mem_kb,
-                nfa_match_min as f64 / dfa_match_min as f64,
+                speedup_tenths / 10,
+                speedup_tenths % 10,
             );
         } else {
             println!("  EagerDFA not convertible at budget {eb}");

--- a/examples/profile_negated.rs
+++ b/examples/profile_negated.rs
@@ -16,7 +16,7 @@ fn main() {
     let long_value = format!("{}x", "a".repeat(1000));
     let event = format!(r#"{{"value": "{long_value}"}}"#).into_bytes();
 
-    let iterations = 1_000_000;
+    let iterations: u128 = 1_000_000;
     let start = std::time::Instant::now();
 
     for _ in 0..iterations {
@@ -24,6 +24,6 @@ fn main() {
     }
 
     let elapsed = start.elapsed();
-    let ns_per_op = elapsed.as_nanos() / iterations as u128;
+    let ns_per_op = elapsed.as_nanos() / iterations;
     eprintln!("{iterations} iterations in {elapsed:.2?} ({ns_per_op} ns/op)",);
 }

--- a/examples/profile_pathological.rs
+++ b/examples/profile_pathological.rs
@@ -46,7 +46,7 @@ fn main() {
         r#"{"val": "aaaaaab"}"#.into(),
     ];
 
-    let iterations = 500_000;
+    let iterations: u128 = 500_000;
     let start = std::time::Instant::now();
 
     for _ in 0..iterations {
@@ -56,15 +56,20 @@ fn main() {
     }
 
     let elapsed = start.elapsed();
-    let total_ops = iterations * events.len();
-    let ns_per_op = elapsed.as_nanos() / total_ops as u128;
+    let events_count = u128::try_from(events.len()).expect("events.len() fits in u128");
+    let total_ops = iterations * events_count;
+    let ns_per_op = elapsed.as_nanos() / total_ops;
+    // ns_per_iter * 1000 / 1000 → integer microseconds with one decimal of
+    // resolution by scaling by 10 first (i.e., "12.3 us/iter" without f64).
+    let tenths_us_per_iter = elapsed.as_nanos() * 10 / iterations / 1_000;
     eprintln!(
-        "{} iterations x {} events = {} ops in {:.2?} ({} ns/op, {:.1} us/iter)",
+        "{} iterations x {} events = {} ops in {:.2?} ({} ns/op, {}.{} us/iter)",
         iterations,
         events.len(),
         total_ops,
         elapsed,
         ns_per_op,
-        elapsed.as_micros() as f64 / iterations as f64,
+        tenths_us_per_iter / 10,
+        tenths_us_per_iter % 10,
     );
 }

--- a/examples/profile_shellstyle.rs
+++ b/examples/profile_shellstyle.rs
@@ -93,7 +93,7 @@ fn main() {
     let events = sample_events();
 
     // Run many iterations for good profiling data
-    let iterations = 100_000;
+    let iterations: u128 = 100_000;
     let start = std::time::Instant::now();
 
     for _ in 0..iterations {
@@ -103,15 +103,19 @@ fn main() {
     }
 
     let elapsed = start.elapsed();
-    let total_ops = iterations * events.len();
-    let ns_per_op = elapsed.as_nanos() / total_ops as u128;
+    let events_count = u128::try_from(events.len()).expect("events.len() fits in u128");
+    let total_ops = iterations * events_count;
+    let ns_per_op = elapsed.as_nanos() / total_ops;
+    // µs/iter with one decimal of resolution, computed in integer space.
+    let tenths_us_per_iter = elapsed.as_nanos() * 10 / iterations / 1_000;
     eprintln!(
-        "{} iterations × {} events = {} ops in {:.2?} ({} ns/op, {:.1} µs/iter)",
+        "{} iterations × {} events = {} ops in {:.2?} ({} ns/op, {}.{} µs/iter)",
         iterations,
         events.len(),
         total_ops,
         elapsed,
         ns_per_op,
-        elapsed.as_micros() as f64 / iterations as f64,
+        tenths_us_per_iter / 10,
+        tenths_us_per_iter % 10,
     );
 }

--- a/justfile
+++ b/justfile
@@ -29,7 +29,7 @@ fmt:
 [group('dev')]
 check:
     cargo check
-    cargo clippy -- -D warnings
+    cargo clippy --all-targets --all-features -- -D warnings
     cargo fmt -- --check
 
 # Run matching benchmarks (optional filter)

--- a/src/automaton/arena.rs
+++ b/src/automaton/arena.rs
@@ -32,7 +32,7 @@ use super::sparse_set::SparseSet;
 /// A state identifier - just an index into the arena.
 ///
 /// `StateId` is a u32 because we want it cheap to copy, hash, and store in
-/// the transition tables. That gives us a ceiling of just under 2³² states
+/// the transition tables. That gives us a ceiling of just under 2^32 states
 /// per arena, which is fine: an arena that big would have run out of memory
 /// long before. The conversions between `usize` and `StateId` rely on that
 /// fact instead of checking it on every alloc.

--- a/src/automaton/arena.rs
+++ b/src/automaton/arena.rs
@@ -26,12 +26,16 @@ use std::sync::Arc;
 use rustc_hash::{FxHashMap, FxHashSet};
 use smallvec::{SmallVec, smallvec};
 
-use super::small_table::{AccelInfo, BYTE_CEILING, FieldMatcher};
+use super::small_table::{AccelInfo, BYTE_CEILING, BYTE_CEILING_U8, FieldMatcher};
 use super::sparse_set::SparseSet;
 
 /// A state identifier - just an index into the arena.
 ///
-/// This can be freely copied and allows cyclic references.
+/// `StateId` is a u32 because we want it cheap to copy, hash, and store in
+/// the transition tables. That gives us a ceiling of just under 2³² states
+/// per arena, which is fine: an arena that big would have run out of memory
+/// long before. The conversions between `usize` and `StateId` rely on that
+/// fact instead of checking it on every alloc.
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
 pub struct StateId(u32);
 
@@ -39,14 +43,20 @@ impl StateId {
     /// Special sentinel value for "no state" / null reference.
     pub const NONE: Self = Self(u32::MAX);
 
-    /// Sentinel for "transition computed and known dead" in the lazy DFA table.
-    /// Distinct from NONE ("not yet computed") so dead transitions are O(1)
-    /// without re-deriving on every call.
+    /// Sentinel for "transition computed and known dead" in the lazy DFA
+    /// table. Distinct from NONE ("not yet computed") so a known-dead
+    /// transition is O(1) instead of being re-derived on every call.
     pub const DEAD: Self = Self(u32::MAX - 1);
 
-    /// Create a `StateId` from an index.
+    /// Build a `StateId` from a `usize` index. `const` so we can construct
+    /// `StateId` arrays and table sentinels at compile time; the truncating
+    /// cast can't overflow in practice (see the type doc).
     #[inline]
     #[must_use]
+    #[allow(
+        clippy::cast_possible_truncation,
+        reason = "StateId encodes a u32-bounded index; arenas can't reach 2^32 states"
+    )]
     pub const fn from_index(index: usize) -> Self {
         Self(index as u32)
     }
@@ -68,6 +78,35 @@ impl StateId {
     pub const fn index(self) -> usize {
         self.0 as usize
     }
+}
+
+/// Narrow a state-count-style `usize` into a `u32`. State counts live
+/// under the same u32 ceiling that `StateId` enforces (see the type doc
+/// on `StateId`); an arena big enough to violate it would have run out
+/// of memory long before.
+///
+/// # Panics
+/// Panics if `count` exceeds `u32::MAX`. In practice unreachable.
+#[inline]
+fn state_count_u32(count: usize, what: &'static str) -> u32 {
+    u32::try_from(count)
+        .unwrap_or_else(|_| panic!("arena {what} exceeds u32::MAX (arena overflow)"))
+}
+
+/// Narrow a flattened-buffer offset (`closure_data`, `ft_ptrs`, …) into a
+/// `u32`. These buffers grow as the *sum* of per-state contents, so they
+/// aren't strictly bounded by `state_count`. In practice each per-state
+/// contribution is small (closures are typically 1-8 entries, field
+/// transitions 0-1) so the offsets fit comfortably; we centralise the
+/// narrowing here so a single point catches it if that assumption ever
+/// breaks.
+///
+/// # Panics
+/// Panics if `offset` exceeds `u32::MAX`. In practice unreachable.
+#[inline]
+fn buffer_offset_u32(offset: usize, what: &'static str) -> u32 {
+    u32::try_from(offset)
+        .unwrap_or_else(|_| panic!("arena {what} exceeds u32::MAX (buffer overflow)"))
 }
 
 /// A state in the arena-based finite automaton.
@@ -148,7 +187,7 @@ impl SmallTable {
     #[must_use]
     pub fn new() -> Self {
         Self {
-            ceilings: smallvec![BYTE_CEILING as u8],
+            ceilings: smallvec![BYTE_CEILING_U8],
             steps: smallvec![StateId::NONE],
             epsilons: SmallVec::new(),
             accel: None,
@@ -185,14 +224,17 @@ impl SmallTable {
         let mut current = unpacked[0];
         for (i, &state_id) in unpacked.iter().enumerate() {
             if state_id != current {
-                self.ceilings.push(i as u8);
+                // `unpacked` has at most BYTE_CEILING (0xF6) entries, so
+                // `i` always fits in u8; `try_from` just keeps it explicit.
+                self.ceilings
+                    .push(u8::try_from(i).expect("unpacked index bounded by BYTE_CEILING"));
                 self.steps.push(current);
                 current = state_id;
             }
         }
 
         // Final entry
-        self.ceilings.push(BYTE_CEILING as u8);
+        self.ceilings.push(BYTE_CEILING_U8);
         self.steps.push(current);
 
         // Note: `default` is not recomputed here. Callers that need it
@@ -474,12 +516,17 @@ impl StateArena {
     }
 
     /// Allocate a new default state, returning its ID.
+    ///
+    /// # Panics
+    /// Panics if the arena's state count or `closure_data` length would
+    /// exceed `u32::MAX`. In practice unreachable: the machine would run
+    /// out of memory long before either counter saturates.
     pub fn alloc(&mut self) -> StateId {
-        let id = StateId(self.states.len() as u32);
+        let id = StateId::from_index(self.states.len());
         // Set trivial epsilon closure so states added after
         // precompute_epsilon_closures() are visible during NFA traversal.
         let state = FaState {
-            closure_start: self.closure_data.len() as u32,
+            closure_start: buffer_offset_u32(self.closure_data.len(), "closure_data length"),
             closure_len: 1,
             ..Default::default()
         };
@@ -489,10 +536,14 @@ impl StateArena {
     }
 
     /// Allocate a new state with the given table, returning its ID.
+    ///
+    /// # Panics
+    /// Panics if the arena's state count or `closure_data` length would
+    /// exceed `u32::MAX`. In practice unreachable; see [`Self::alloc`].
     pub fn alloc_with_table(&mut self, table: SmallTable) -> StateId {
-        let id = StateId(self.states.len() as u32);
+        let id = StateId::from_index(self.states.len());
         let mut state = FaState::with_table(table);
-        state.closure_start = self.closure_data.len() as u32;
+        state.closure_start = buffer_offset_u32(self.closure_data.len(), "closure_data length");
         state.closure_len = 1;
         self.closure_data.push(id);
         self.states.push(state);
@@ -551,22 +602,28 @@ impl StateArena {
         let mut states_with_closures = 0u32;
 
         for state in &self.states {
-            // Table stats: count states that have non-trivial transitions
-            // (more than just the default catch-all entry)
+            // We only count states with non-trivial transitions (i.e.
+            // more than the default catch-all entry). Per-state table
+            // sizes are bounded by `BYTE_CEILING` (246), so the narrowing
+            // to u16 and u32 here can't actually fail at runtime; we route
+            // through `try_from` only to keep the casts explicit.
             let nc = state.table.ceilings.len();
             if nc > 1 {
                 tables_with_transitions += 1;
-                total_ceiling_entries += nc as u32;
-                if nc > max_ceilings as usize {
-                    max_ceilings = nc as u16;
+                total_ceiling_entries +=
+                    u32::try_from(nc).expect("ceiling count bounded by BYTE_CEILING");
+                let nc_u16 = u16::try_from(nc).expect("ceiling count bounded by BYTE_CEILING");
+                if nc_u16 > max_ceilings {
+                    max_ceilings = nc_u16;
                 }
             }
 
             let ne = state.table.epsilons.len();
             if ne > 0 {
-                total_epsilons += ne as u32;
-                if ne > max_epsilons as usize {
-                    max_epsilons = ne as u16;
+                total_epsilons += u32::try_from(ne).expect("epsilon count bounded by BYTE_CEILING");
+                let ne_u16 = u16::try_from(ne).expect("epsilon count bounded by BYTE_CEILING");
+                if ne_u16 > max_epsilons {
+                    max_epsilons = ne_u16;
                 }
             }
 
@@ -590,19 +647,19 @@ impl StateArena {
         };
 
         Stats {
-            state_count: state_count as u32,
+            state_count: state_count_u32(state_count, "state count"),
             tables_with_transitions,
             total_ceiling_entries,
             max_ceilings,
             total_epsilons,
             max_epsilons,
             states_with_field_transitions,
-            closure_data_len: self.closure_data.len() as u32,
+            closure_data_len: buffer_offset_u32(self.closure_data.len(), "closure_data length"),
             states_with_closures,
             total_closure_entries,
             max_closure_len,
-            ft_ptrs_len: self.ft_ptrs.len() as u32,
-            dfa_lookup_states: dfa_lookup_states as u32,
+            ft_ptrs_len: buffer_offset_u32(self.ft_ptrs.len(), "ft_ptrs length"),
+            dfa_lookup_states: state_count_u32(dfa_lookup_states, "dfa_lookup state count"),
             estimated_bytes: self.estimated_byte_size(),
         }
     }
@@ -642,7 +699,7 @@ impl StateArena {
 
         for state_idx in 0..arena_len {
             let state_id = StateId::from_index(state_idx);
-            let start = closure_data.len() as u32;
+            let start = buffer_offset_u32(closure_data.len(), "closure_data length");
 
             if self.states[state_idx].table.epsilons.is_empty() {
                 // DFA state: closure is just [self]
@@ -674,11 +731,8 @@ impl StateArena {
                     }
                 }
 
-                debug_assert!(
-                    u16::try_from(closure_buf.len()).is_ok(),
-                    "epsilon closure exceeds u16::MAX states"
-                );
-                let len = closure_buf.len() as u16;
+                let len = u16::try_from(closure_buf.len())
+                    .expect("epsilon closure exceeds u16::MAX states");
                 closure_data.extend_from_slice(&closure_buf);
                 self.states[state_idx].closure_start = start;
                 self.states[state_idx].closure_len = len;
@@ -718,8 +772,13 @@ impl StateArena {
             for ft in &state.field_transitions {
                 ft_ptrs.push(Arc::as_ptr(ft) as usize);
             }
-            self.states[state_idx].ft_start = ft_start as u32;
-            self.states[state_idx].ft_len = ft_len as u8;
+            self.states[state_idx].ft_start = buffer_offset_u32(ft_start, "ft_start offset");
+            // `ft_len` is u8 because we expect 0 or 1 field transitions per
+            // state in practice (the SmallVec is sized for that). Anything
+            // approaching 256 would mean something else has already gone
+            // very wrong.
+            self.states[state_idx].ft_len =
+                u8::try_from(ft_len).expect("per-state field_transitions.len() fits in u8");
         }
         self.ft_ptrs = ft_ptrs;
     }
@@ -922,15 +981,19 @@ impl StateArena {
             let mut exit_count = 0u8;
             let mut exit_bytes = [0u8; 3];
 
+            // We only walk the ASCII slice (0x00..0x80), so `byte` always
+            // fits in u8 — `try_from` here is just paranoia.
             for (byte, &target) in unpacked[..0x80].iter().enumerate() {
                 if target == state_id {
                     has_self_loop = true;
                 } else {
-                    // Exit byte: either a real transition or a rejection (NONE).
-                    // Both are valid — memchr skips to this byte; if NONE, the
-                    // traversal exits early, which is the correct rejection behavior.
+                    // An exit byte is either a real transition or a
+                    // rejection (NONE). Either way, memchr can skip
+                    // straight to it: if it's NONE, traversal exits
+                    // early, which is the correct rejection behaviour.
                     if exit_count < 3 {
-                        exit_bytes[exit_count as usize] = byte as u8;
+                        exit_bytes[exit_count as usize] =
+                            u8::try_from(byte).expect("ASCII range bounded above by 0x80");
                     }
                     exit_count += 1;
                 }
@@ -1651,7 +1714,7 @@ pub fn merge_arena_dfas(
 
     // Memoization: (state1_id, state2_id) -> merged_state_id in new arena.
     // i32 lets us encode StateId::NONE as -1.
-    let mut memo: FxHashMap<(i32, i32), StateId> = FxHashMap::default();
+    let mut memo: FxHashMap<(StateId, StateId), StateId> = FxHashMap::default();
     let mut new_arena = StateArena::new();
 
     let start =
@@ -1741,20 +1804,11 @@ fn merge_arena_states_recursive(
     arena2: &StateArena,
     state2: StateId,
     new_arena: &mut StateArena,
-    memo: &mut FxHashMap<(i32, i32), StateId>,
+    memo: &mut FxHashMap<(StateId, StateId), StateId>,
 ) -> StateId {
-    // Convert to memo key (using -1 for NONE)
-    let key1 = if state1.is_none() {
-        -1
-    } else {
-        state1.0 as i32
-    };
-    let key2 = if state2.is_none() {
-        -1
-    } else {
-        state2.0 as i32
-    };
-    let key = (key1, key2);
+    // Memo by `(StateId, StateId)`. `StateId::NONE` already encodes the
+    // "no state on this side" key without needing a separate sentinel.
+    let key = (state1, state2);
 
     // Check memo
     if let Some(&cached) = memo.get(&key) {
@@ -1808,7 +1862,7 @@ fn remap_table_recursive(
     table: &SmallTable,
     _other_arena: &StateArena,
     new_arena: &mut StateArena,
-    memo: &mut FxHashMap<(i32, i32), StateId>,
+    memo: &mut FxHashMap<(StateId, StateId), StateId>,
     is_arena1: bool,
 ) -> SmallTable {
     let mut new_table = SmallTable {
@@ -1907,7 +1961,7 @@ fn merge_arena_tables(
     arena2: &StateArena,
     table2: &SmallTable,
     new_arena: &mut StateArena,
-    memo: &mut FxHashMap<(i32, i32), StateId>,
+    memo: &mut FxHashMap<(StateId, StateId), StateId>,
 ) -> SmallTable {
     // Unpack both tables to 256-element arrays for simplicity
     let mut unpacked1 = [StateId::NONE; BYTE_CEILING];
@@ -2006,7 +2060,7 @@ pub fn merge_arena_nfas(
     }
 
     // Memoization: (state1_id, state2_id) -> merged_state_id in new arena.
-    let mut memo: FxHashMap<(i32, i32), StateId> = FxHashMap::default();
+    let mut memo: FxHashMap<(StateId, StateId), StateId> = FxHashMap::default();
     let mut new_arena = StateArena::new();
 
     let start =
@@ -2086,20 +2140,11 @@ fn merge_arena_nfa_states_recursive(
     arena2: &StateArena,
     state2: StateId,
     new_arena: &mut StateArena,
-    memo: &mut FxHashMap<(i32, i32), StateId>,
+    memo: &mut FxHashMap<(StateId, StateId), StateId>,
 ) -> StateId {
-    // Convert to memo key (using -1 for NONE)
-    let key1 = if state1.is_none() {
-        -1
-    } else {
-        state1.0 as i32
-    };
-    let key2 = if state2.is_none() {
-        -1
-    } else {
-        state2.0 as i32
-    };
-    let key = (key1, key2);
+    // Memo by `(StateId, StateId)`. `StateId::NONE` already encodes the
+    // "no state on this side" key without needing a separate sentinel.
+    let key = (state1, state2);
 
     // Check memo
     if let Some(&cached) = memo.get(&key) {
@@ -2180,7 +2225,7 @@ fn merge_arena_nfa_states_recursive(
         let epsilons = flatten_epsilon_targets(new_arena, &[cloned1, cloned2]);
 
         new_arena[new_id].table = SmallTable {
-            ceilings: smallvec![BYTE_CEILING as u8],
+            ceilings: smallvec![BYTE_CEILING_U8],
             steps: smallvec![StateId::NONE],
             epsilons,
             accel: None,
@@ -2213,7 +2258,7 @@ fn merge_dual_spinout_states(
     arena2: &StateArena,
     s2: &FaState,
     new_arena: &mut StateArena,
-    memo: &mut FxHashMap<(i32, i32), StateId>,
+    memo: &mut FxHashMap<(StateId, StateId), StateId>,
     new_id: StateId,
 ) {
     let mut combined_table =
@@ -2257,7 +2302,7 @@ fn asymmetric_spinner_merge(
     state2: StateId,
     s1_has_spinout: bool,
     new_arena: &mut StateArena,
-    memo: &mut FxHashMap<(i32, i32), StateId>,
+    memo: &mut FxHashMap<(StateId, StateId), StateId>,
     new_id: StateId,
 ) -> StateId {
     let s1 = &arena1[state1];
@@ -2343,7 +2388,7 @@ fn merge_asymmetric_spinner_byte(
     other_next: StateId,
     s1_has_spinout: bool,
     new_arena: &mut StateArena,
-    memo: &mut FxHashMap<(i32, i32), StateId>,
+    memo: &mut FxHashMap<(StateId, StateId), StateId>,
     new_id: StateId,
     arena1: &StateArena,
     state1: StateId,
@@ -2513,7 +2558,7 @@ fn remap_nfa_table_recursive(
     table: &SmallTable,
     _other_arena: &StateArena,
     new_arena: &mut StateArena,
-    memo: &mut FxHashMap<(i32, i32), StateId>,
+    memo: &mut FxHashMap<(StateId, StateId), StateId>,
     is_arena1: bool,
 ) -> SmallTable {
     let mut new_table = SmallTable {
@@ -2612,7 +2657,7 @@ fn merge_nfa_tables_bytewise(
     arena2: &StateArena,
     table2: &SmallTable,
     new_arena: &mut StateArena,
-    memo: &mut FxHashMap<(i32, i32), StateId>,
+    memo: &mut FxHashMap<(StateId, StateId), StateId>,
 ) -> SmallTable {
     // Unpack both tables to 256-element arrays
     let mut unpacked1 = [StateId::NONE; BYTE_CEILING];
@@ -2859,7 +2904,7 @@ fn make_greater_arena_fa_step(
 
     // Bytes > bound_byte: input > bound, MATCH
     // But exclude VALUE_TERMINATOR - it means input is shorter, so input < bound
-    for b in (bound_byte + 1)..(BYTE_CEILING as u8) {
+    for b in (bound_byte + 1)..(BYTE_CEILING_U8) {
         if b != ARENA_VALUE_TERMINATOR {
             unpacked[b as usize] = match_state;
         }
@@ -3387,7 +3432,7 @@ fn build_fa_from_segments(
 /// eliminating the need for a separate spinout check in the traversal loop.
 fn make_byte_dot_table(dest: StateId) -> SmallTable {
     let mut table = SmallTable::new();
-    table.ceilings = smallvec![0xC0, 0xC2, ARENA_VALUE_TERMINATOR, BYTE_CEILING as u8];
+    table.ceilings = smallvec![0xC0, 0xC2, ARENA_VALUE_TERMINATOR, BYTE_CEILING_U8];
     table.steps = smallvec![dest, StateId::NONE, dest, StateId::NONE];
     table.default = dest;
     table
@@ -4892,16 +4937,16 @@ mod arena_stats_utility_tests {
         let s3 = arena.alloc();
 
         // s0: 2 ceilings (non-trivial), 0 epsilons
-        arena[s0].table.ceilings = smallvec![b'a', BYTE_CEILING as u8];
+        arena[s0].table.ceilings = smallvec![b'a', BYTE_CEILING_U8];
         arena[s0].table.steps = smallvec![s1, StateId::NONE];
 
         // s1: 3 ceilings (non-trivial), 1 epsilon
-        arena[s1].table.ceilings = smallvec![b'a', b'b', BYTE_CEILING as u8];
+        arena[s1].table.ceilings = smallvec![b'a', b'b', BYTE_CEILING_U8];
         arena[s1].table.steps = smallvec![s0, s2, StateId::NONE];
         arena[s1].table.epsilons.push(s3);
 
         // s2: 4 ceilings (non-trivial), 2 epsilons
-        arena[s2].table.ceilings = smallvec![b'a', b'b', b'c', BYTE_CEILING as u8];
+        arena[s2].table.ceilings = smallvec![b'a', b'b', b'c', BYTE_CEILING_U8];
         arena[s2].table.steps = smallvec![s0, s1, s3, StateId::NONE];
         arena[s2].table.epsilons.push(s0);
         arena[s2].table.epsilons.push(s1);

--- a/src/automaton/mod.rs
+++ b/src/automaton/mod.rs
@@ -21,7 +21,9 @@ pub(crate) mod sparse_set;
 mod thread_safe;
 
 // Re-export from small_table
-pub use small_table::{AccelInfo, BYTE_CEILING, FieldMatcher, NfaBuffers, VALUE_TERMINATOR};
+pub use small_table::{
+    AccelInfo, BYTE_CEILING, BYTE_CEILING_U8, FieldMatcher, NfaBuffers, VALUE_TERMINATOR,
+};
 
 // Re-export from mutable_matcher
 pub use mutable_matcher::{

--- a/src/automaton/small_table.rs
+++ b/src/automaton/small_table.rs
@@ -11,9 +11,16 @@ use std::sync::Arc;
 
 use rustc_hash::FxHashMap;
 
-/// Maximum byte value we handle. UTF-8 bytes 0xF5-0xFF can't appear in valid strings.
-/// We use 0xF5 as a value terminator.
+/// Maximum byte value we handle.
+///
+/// UTF-8 bytes 0xF5-0xFF can't appear in valid strings, and we steal 0xF5
+/// as a value terminator, so 0xF6 and up never occur. Exposed in both
+/// widths because some call sites want to index a 256-entry array (so
+/// `usize`) while others want to slot the value straight into a `u8`
+/// table entry; an explicit second constant beats scattering `as u8`
+/// casts across the module.
 pub const BYTE_CEILING: usize = 0xF6;
+pub const BYTE_CEILING_U8: u8 = 0xF6;
 
 /// Marks the end of a value being matched. This simplifies handling of exact matches
 /// vs prefix matches - we always add this terminator to both the pattern and the value.

--- a/src/automaton/tests.rs
+++ b/src/automaton/tests.rs
@@ -114,7 +114,7 @@ fn test_arena_small_table_step() {
     let table = SmallTable::new();
 
     // Test that all valid bytes return NONE for empty table
-    for b in 0..BYTE_CEILING as u8 {
+    for b in 0..BYTE_CEILING_U8 {
         let (s, eps) = table.step(b);
         assert!(
             s.is_none(),

--- a/src/flatten_json.rs
+++ b/src/flatten_json.rs
@@ -707,35 +707,7 @@ impl<'a> FlattenContext<'a, '_> {
                     b't' => name.push(b'\t'),
                     b'u' => {
                         self.index += 1;
-                        let code = self.read_hex_4()?;
-                        if code < 0x80 {
-                            name.push(code as u8);
-                        } else if code < 0x800 {
-                            name.push(0xC0 | ((code >> 6) as u8));
-                            name.push(0x80 | ((code & 0x3F) as u8));
-                        } else if (0xD800..=0xDBFF).contains(&code) {
-                            // High surrogate - check for low surrogate
-                            if self.index + 5 < self.event.len()
-                                && self.event[self.index] == b'\\'
-                                && self.event[self.index + 1] == b'u'
-                            {
-                                self.index += 2;
-                                let low = self.read_hex_4()?;
-                                if (0xDC00..=0xDFFF).contains(&low) {
-                                    let full = 0x10000 + ((code - 0xD800) << 10) + (low - 0xDC00);
-                                    name.push(0xF0 | ((full >> 18) as u8));
-                                    name.push(0x80 | (((full >> 12) & 0x3F) as u8));
-                                    name.push(0x80 | (((full >> 6) & 0x3F) as u8));
-                                    name.push(0x80 | ((full & 0x3F) as u8));
-                                    // Don't decrement here - the decrement at end of b'u' case handles it
-                                }
-                            }
-                        } else {
-                            name.push(0xE0 | ((code >> 12) as u8));
-                            name.push(0x80 | (((code >> 6) & 0x3F) as u8));
-                            name.push(0x80 | ((code & 0x3F) as u8));
-                        }
-                        self.index -= 1;
+                        self.read_unicode_escape(&mut name)?;
                     }
                     _ => {
                         return Err(FlattenError::Error(
@@ -809,38 +781,9 @@ impl<'a> FlattenContext<'a, '_> {
                     b'r' => val.push(b'\r'),
                     b't' => val.push(b'\t'),
                     b'u' => {
-                        // Unicode escape - parse 4 hex digits
+                        // Unicode escape - parse 4 hex digits.
                         self.index += 1;
-                        let code = self.read_hex_4()?;
-                        // Simple case: BMP character
-                        if code < 0x80 {
-                            val.push(code as u8);
-                        } else if code < 0x800 {
-                            val.push(0xC0 | ((code >> 6) as u8));
-                            val.push(0x80 | ((code & 0x3F) as u8));
-                        } else if (0xD800..=0xDBFF).contains(&code) {
-                            // High surrogate - check for low surrogate
-                            if self.index + 5 < self.event.len()
-                                && self.event[self.index] == b'\\'
-                                && self.event[self.index + 1] == b'u'
-                            {
-                                self.index += 2;
-                                let low = self.read_hex_4()?;
-                                if (0xDC00..=0xDFFF).contains(&low) {
-                                    let full = 0x10000 + ((code - 0xD800) << 10) + (low - 0xDC00);
-                                    val.push(0xF0 | ((full >> 18) as u8));
-                                    val.push(0x80 | (((full >> 12) & 0x3F) as u8));
-                                    val.push(0x80 | (((full >> 6) & 0x3F) as u8));
-                                    val.push(0x80 | ((full & 0x3F) as u8));
-                                    // Don't decrement here - the decrement at end of b'u' case handles it
-                                }
-                            }
-                        } else {
-                            val.push(0xE0 | ((code >> 12) as u8));
-                            val.push(0x80 | (((code >> 6) & 0x3F) as u8));
-                            val.push(0x80 | ((code & 0x3F) as u8));
-                        }
-                        self.index -= 1; // will be incremented at end of loop
+                        self.read_unicode_escape(&mut val)?;
                     }
                     _ => {
                         return Err(FlattenError::Error(self.error("malformed escape in text")));
@@ -857,6 +800,70 @@ impl<'a> FlattenContext<'a, '_> {
         }
 
         Err(FlattenError::Error(self.error("premature end of event")))
+    }
+
+    /// Decode a `\uXXXX` escape (we've already stepped past the `u`) and
+    /// append its UTF-8 bytes to `out`. JSON allows any 4-hex code unit,
+    /// which includes the UTF-16 surrogate halves; if the next bytes are
+    /// also a `\u` we try to assemble a surrogate pair, otherwise we have
+    /// to do something with the lone half.
+    ///
+    /// The interesting cases:
+    ///
+    ///   - high surrogate + low surrogate: combine into the supplementary
+    ///     code point and let `char::encode_utf8` emit the 4-byte sequence.
+    ///   - high surrogate followed by anything else: drop it. The Go
+    ///     flattener does the same; we still consume the hex digits.
+    ///   - lone low surrogate (`U+DC00..U+DFFF`): `char::from_u32` rejects
+    ///     this, but the Go flattener emits the 3-byte WTF-8 form. We do
+    ///     the same so byte-for-byte round-tripping holds for inputs that
+    ///     contain it.
+    ///   - everything else: encode via `char::encode_utf8`, same 1-3 bytes
+    ///     the old hand-rolled code produced.
+    ///
+    /// On return `self.index` sits on the last hex digit we consumed; the
+    /// caller's outer `index += 1` advances past it, so don't decrement.
+    fn read_unicode_escape(&mut self, out: &mut Vec<u8>) -> Result<(), FlattenError> {
+        let code = self.read_hex_4()?;
+
+        if (0xD800..=0xDBFF).contains(&code) {
+            // High surrogate — try to consume the matching low surrogate.
+            if self.index + 5 < self.event.len()
+                && self.event[self.index] == b'\\'
+                && self.event[self.index + 1] == b'u'
+            {
+                self.index += 2;
+                let low = self.read_hex_4()?;
+                if (0xDC00..=0xDFFF).contains(&low) {
+                    let full = 0x10000 + ((code - 0xD800) << 10) + (low - 0xDC00);
+                    if let Some(c) = char::from_u32(full) {
+                        let mut buf = [0u8; 4];
+                        out.extend_from_slice(c.encode_utf8(&mut buf).as_bytes());
+                    }
+                }
+            }
+        } else if let Some(c) = char::from_u32(code) {
+            let mut buf = [0u8; 4];
+            out.extend_from_slice(c.encode_utf8(&mut buf).as_bytes());
+        } else {
+            // `read_hex_4` only returns 0..=0xFFFF, and we've already taken
+            // the high-surrogate path above, so the only thing that can
+            // make `char::from_u32` give up is a lone low surrogate. Emit
+            // it as 3-byte WTF-8 by hand. Each masked piece is statically
+            // bounded so the `try_from`s never actually fail.
+            debug_assert!(
+                (0xDC00..=0xDFFF).contains(&code),
+                "char::from_u32 only fails for surrogates within u16 range"
+            );
+            out.push(0xE0 | u8::try_from(code >> 12).expect("code >> 12 fits in 4 bits"));
+            out.push(
+                0x80 | u8::try_from((code >> 6) & 0x3F).expect("masked to 6 bits, fits in u8"),
+            );
+            out.push(0x80 | u8::try_from(code & 0x3F).expect("masked to 6 bits, fits in u8"));
+        }
+
+        self.index -= 1;
+        Ok(())
     }
 
     /// Read 4 hex digits for a \uXXXX escape.
@@ -1744,6 +1751,21 @@ x"#,
             fields[0].val.as_bytes(),
             &[b'"', 0xF0, 0x9F, 0x98, 0x80, b'"']
         );
+    }
+
+    #[test]
+    fn test_unicode_escape_lone_low_surrogate_in_value() {
+        // A `\uDEAD` not preceded by a high surrogate isn't a valid Unicode
+        // scalar, so `char::from_u32` rejects it. The flattener falls back
+        // to emitting the WTF-8 3-byte form, matching the upstream Go
+        // flattener so byte-for-byte round-tripping holds.
+        let tree = make_tree(&["v"]);
+        let mut state = State::new();
+        let event = br#"{"v": "\uDEAD"}"#;
+        let fields = state.flatten(event, &tree).unwrap();
+        assert_eq!(fields.len(), 1);
+        // U+DEAD as 3-byte WTF-8: 0xED 0xBA 0xAD
+        assert_eq!(fields[0].val.as_bytes(), &[b'"', 0xED, 0xBA, 0xAD, b'"']);
     }
 
     #[test]

--- a/src/flatten_json.rs
+++ b/src/flatten_json.rs
@@ -823,6 +823,7 @@ impl<'a> FlattenContext<'a, '_> {
     ///
     /// On return `self.index` sits on the last hex digit we consumed; the
     /// caller's outer `index += 1` advances past it, so don't decrement.
+    #[inline]
     fn read_unicode_escape(&mut self, out: &mut Vec<u8>) -> Result<(), FlattenError> {
         let code = self.read_hex_4()?;
 

--- a/src/json.rs
+++ b/src/json.rs
@@ -147,16 +147,18 @@ impl CidrPattern {
             // Fill left part
             for (i, part) in left.iter().enumerate() {
                 let val = u16::from_str_radix(part, 16).ok()?;
-                addr[i * 2] = (val >> 8) as u8;
-                addr[i * 2 + 1] = val as u8;
+                let [hi, lo] = val.to_be_bytes();
+                addr[i * 2] = hi;
+                addr[i * 2 + 1] = lo;
             }
 
             // Fill right part (from the end)
             let right_start = 8 - right.len();
             for (i, part) in right.iter().enumerate() {
                 let val = u16::from_str_radix(part, 16).ok()?;
-                addr[(right_start + i) * 2] = (val >> 8) as u8;
-                addr[(right_start + i) * 2 + 1] = val as u8;
+                let [hi, lo] = val.to_be_bytes();
+                addr[(right_start + i) * 2] = hi;
+                addr[(right_start + i) * 2 + 1] = lo;
             }
         } else {
             // Full address
@@ -166,8 +168,9 @@ impl CidrPattern {
             }
             for (i, part) in parts.iter().enumerate() {
                 let val = u16::from_str_radix(part, 16).ok()?;
-                addr[i * 2] = (val >> 8) as u8;
-                addr[i * 2 + 1] = val as u8;
+                let [hi, lo] = val.to_be_bytes();
+                addr[i * 2] = hi;
+                addr[i * 2 + 1] = lo;
             }
         }
 
@@ -454,7 +457,11 @@ fn compute_branch_byte_length(branch: &RegexpBranch) -> Result<usize, String> {
         if atom.quant_min != atom.quant_max {
             return Err("variable quantifier in lookbehind not supported".into());
         }
-        let count = atom.quant_min as usize;
+        // Quantifier counts come out of the parser non-negative; if a stray
+        // negative ever reaches here we'd rather raise a clear error than
+        // wrap into an enormous usize.
+        let count = usize::try_from(atom.quant_min)
+            .map_err(|_| "negative quantifier count in lookbehind".to_owned())?;
 
         // Compute per-atom byte length
         let atom_len = if atom.is_dot {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,9 +100,12 @@ impl PrunerStats {
             return false;
         }
 
-        // Trigger rebuild when filtered/emitted > 0.2
-        let ratio = filtered as f64 / emitted as f64;
-        ratio > 0.2
+        // Rebuild when filtered/emitted > 0.2, which we'd rather check
+        // without an f64 detour: 5*filtered > emitted is the same condition
+        // in integers. `checked_mul` returning None means filtered is so
+        // huge (≥ 2^61) we're well overdue for a rebuild anyway, so we
+        // treat it as "yes, rebuild".
+        filtered.checked_mul(5).is_none_or(|fx5| fx5 > emitted)
     }
 }
 

--- a/src/numbits.rs
+++ b/src/numbits.rs
@@ -105,10 +105,12 @@ pub(crate) fn to_q_number_stack(nb: u64) -> QNumberStack {
         nb >>= 7;
     }
 
-    // Total length = 1 (prefix) + content_len
+    // Total length = prefix + content. `content_len` is bounded by
+    // MAX_BYTES_IN_ENCODING - 1 (i.e. 10), so the sum never overflows u8.
     QNumberStack {
         bytes,
-        len: (1 + content_len) as u8,
+        len: u8::try_from(1 + content_len)
+            .expect("Q-number length bounded by MAX_BYTES_IN_ENCODING"),
     }
 }
 
@@ -135,11 +137,15 @@ pub fn q_num_stack(f: f64) -> QNumberStack {
 /// rules and Quamina's parsers prevent those values from occurring.
 pub(crate) const fn numbits_from_f64(f: f64) -> u64 {
     let u = f.to_bits();
-    // Transform without branching:
-    // If high bit is 0, xor with sign bit (1 << 63), else negate (xor with !0).
-    // Using a sign extending right shift was proposed by Raph Levien in
-    // https://mastodon.online/@raph/113071041069390831
-    let mask = ((u as i64 >> 63) as u64) | (1 << 63);
+    // Branchless transform: if the high bit is 0, XOR with the sign bit
+    // (1 << 63); if it's 1, negate (XOR with !0). Raph Levien spotted that
+    // a sign-extending right shift gives us the right mask for free —
+    // see https://mastodon.online/@raph/113071041069390831 .
+    //
+    // `cast_signed` / `cast_unsigned` reinterpret the bits without changing
+    // the value, so the `>> 63` between them is the arithmetic shift that
+    // turns into a single instruction.
+    let mask = (u.cast_signed() >> 63).cast_unsigned() | (1 << 63);
     u ^ mask
 }
 
@@ -312,9 +318,10 @@ mod tests {
 
         for _ in 0..count {
             rng_state = rng_state.wrapping_mul(6364136223846793005).wrapping_add(1);
-            let random_u64 = rng_state;
-            let f = ((random_u64 as f64) / (u64::MAX as f64))
-                .mul_add(2_000_000_000.0, -1_000_000_000.0);
+            // Stuff 52 random bits into a 1.0-exponent and subtract 1.0 to
+            // get a uniform [0.0, 1.0) without any lossy `as f64` cast.
+            let unit = f64::from_bits((rng_state >> 12) | 0x3FF0_0000_0000_0000) - 1.0;
+            let f = unit.mul_add(2_000_000_000.0, -1_000_000_000.0);
             floats.push(f);
         }
 

--- a/src/regexp/nfa.rs
+++ b/src/regexp/nfa.rs
@@ -205,9 +205,12 @@ fn make_one_arena_branch_fa(
             // No quantifier - simple FA
             current_next = make_arena_atom_fa(qa, arena, current_next);
         } else {
-            // General {n,m} quantifier
-            let n = qa.quant_min as usize;
-            let m = qa.quant_max as usize;
+            // General {n,m} quantifier. The parser only ever stores
+            // non-negative counts here; if that ever stops being true we'd
+            // rather panic than silently turn a stray -1 into a 4-billion-
+            // iteration loop.
+            let n = usize::try_from(qa.quant_min).expect("quant_min must be non-negative");
+            let m = usize::try_from(qa.quant_max).expect("quant_max must be non-negative");
 
             // Special case: {0,0} means match zero times - pure epsilon transition
             if n == 0 && m == 0 {
@@ -266,10 +269,13 @@ fn create_arena_plus_star_loop(
     // Only ASCII-only negated patterns can be accelerated.
     // Unicode patterns have too many exit bytes (68+) for memchr to help.
     let accel = qa.ascii_negated_bytes.as_ref().map(|bytes| {
-        // ASCII-only negated pattern: use the negated bytes as exit bytes directly
+        // ASCII-only negated pattern: feed the negated bytes straight in
+        // as exit bytes. `detect_ascii_negated_bytes` already declines
+        // anything with more than 3 entries, so neither the `try_from`
+        // nor the indexed write can overflow.
         let mut accel = crate::automaton::AccelInfo {
             exit_bytes: [0; 3],
-            len: bytes.len() as u8,
+            len: u8::try_from(bytes.len()).expect("ascii_negated_bytes is bounded to 3"),
         };
         for (i, &b) in bytes.iter().enumerate() {
             accel.exit_bytes[i] = b;
@@ -471,7 +477,8 @@ fn build_shell(rr: &RuneRange) -> CachedShell {
 
     CachedShell {
         tables,
-        root: root_id.index() as u32,
+        root: u32::try_from(root_id.index())
+            .expect("shell arenas have far fewer than u32::MAX states"),
     }
 }
 

--- a/src/regexp/parser.rs
+++ b/src/regexp/parser.rs
@@ -430,8 +430,10 @@ fn branch_fixed_length(branch: &Branch) -> Option<usize> {
             0 // Empty atom
         };
 
-        // Multiply by quantifier
-        total += atom_len * (atom.quant_min as usize);
+        // Multiply by quantifier. The parser doesn't produce negative
+        // counts here, but if that ever changed we'd rather call the
+        // length unknown (None) than wrap a -1 into a giant usize.
+        total += atom_len * usize::try_from(atom.quant_min).ok()?;
     }
     Some(total)
 }

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -1,5 +1,18 @@
 //! Shared test helper macros and functions to reduce duplication across test modules.
 
+/// Adapter the test macros run an event through on the way into
+/// `matches_for_event`. We want tests to keep writing events as raw string
+/// literals like `r#"{"x": 1}"#`, but calling `.as_bytes()` directly inside
+/// a macro upsets clippy, and the byte-string literal alternative ruins the
+/// readability of every test. Bouncing through this fn sidesteps the warning
+/// without forcing every test to learn to spell `br#"..."#`.
+#[doc(hidden)]
+#[inline]
+#[must_use]
+pub fn event_bytes<E: AsRef<[u8]> + ?Sized>(event: &E) -> &[u8] {
+    event.as_ref()
+}
+
 /// Create a `Quamina` matcher pre-loaded with one or more patterns.
 ///
 /// ```ignore
@@ -21,11 +34,15 @@ macro_rules! q {
 /// ```
 macro_rules! assert_matches {
     ($q:expr, $event:expr, $expected:expr) => {{
-        let matches = $q.matches_for_event($event.as_bytes()).unwrap();
+        let matches = $q
+            .matches_for_event($crate::test_helpers::event_bytes(&$event))
+            .unwrap();
         assert_eq!(matches, $expected, "Event: {}", $event);
     }};
     ($q:expr, $event:expr, $expected:expr, $msg:expr) => {{
-        let matches = $q.matches_for_event($event.as_bytes()).unwrap();
+        let matches = $q
+            .matches_for_event($crate::test_helpers::event_bytes(&$event))
+            .unwrap();
         assert_eq!(matches, $expected, "{} (event: {})", $msg, $event);
     }};
 }
@@ -38,11 +55,15 @@ macro_rules! assert_matches {
 /// ```
 macro_rules! assert_no_match {
     ($q:expr, $event:expr) => {{
-        let matches = $q.matches_for_event($event.as_bytes()).unwrap();
+        let matches = $q
+            .matches_for_event($crate::test_helpers::event_bytes(&$event))
+            .unwrap();
         assert!(matches.is_empty(), "Expected no match for: {}", $event);
     }};
     ($q:expr, $event:expr, $msg:expr) => {{
-        let matches = $q.matches_for_event($event.as_bytes()).unwrap();
+        let matches = $q
+            .matches_for_event($crate::test_helpers::event_bytes(&$event))
+            .unwrap();
         assert!(matches.is_empty(), "{} (event: {})", $msg, $event);
     }};
 }
@@ -54,7 +75,9 @@ macro_rules! assert_no_match {
 /// ```
 macro_rules! assert_has_match {
     ($q:expr, $event:expr, $name:expr) => {{
-        let matches = $q.matches_for_event($event.as_bytes()).unwrap();
+        let matches = $q
+            .matches_for_event($crate::test_helpers::event_bytes(&$event))
+            .unwrap();
         assert!(
             matches.contains(&$name),
             "Expected {:?} in matches for {}, got {:?}",
@@ -64,7 +87,9 @@ macro_rules! assert_has_match {
         );
     }};
     ($q:expr, $event:expr, $name:expr, $msg:expr) => {{
-        let matches = $q.matches_for_event($event.as_bytes()).unwrap();
+        let matches = $q
+            .matches_for_event($crate::test_helpers::event_bytes(&$event))
+            .unwrap();
         assert!(
             matches.contains(&$name),
             "{}: expected {:?} in matches for {}, got {:?}",
@@ -83,7 +108,9 @@ macro_rules! assert_has_match {
 /// ```
 macro_rules! assert_no_has_match {
     ($q:expr, $event:expr, $name:expr) => {{
-        let matches = $q.matches_for_event($event.as_bytes()).unwrap();
+        let matches = $q
+            .matches_for_event($crate::test_helpers::event_bytes(&$event))
+            .unwrap();
         assert!(
             !matches.contains(&$name),
             "Expected {:?} NOT in matches for {}, got {:?}",
@@ -101,7 +128,9 @@ macro_rules! assert_no_has_match {
 /// ```
 macro_rules! assert_match_count {
     ($q:expr, $event:expr, $count:expr) => {{
-        let matches = $q.matches_for_event($event.as_bytes()).unwrap();
+        let matches = $q
+            .matches_for_event($crate::test_helpers::event_bytes(&$event))
+            .unwrap();
         assert_eq!(
             matches.len(),
             $count,
@@ -112,7 +141,9 @@ macro_rules! assert_match_count {
         );
     }};
     ($q:expr, $event:expr, $count:expr, $msg:expr) => {{
-        let matches = $q.matches_for_event($event.as_bytes()).unwrap();
+        let matches = $q
+            .matches_for_event($crate::test_helpers::event_bytes(&$event))
+            .unwrap();
         assert_eq!(
             matches.len(),
             $count,

--- a/src/tests_core.rs
+++ b/src/tests_core.rs
@@ -1192,10 +1192,13 @@ fn test_numbits_to_qnumber_utf8() {
             .wrapping_mul(6364136223846793005)
             .wrapping_add(1442695040888963407);
 
-        // Generate a random f64 in a wide range
+        // Generate a random f64 in a wide range. We build the mantissa via
+        // the standard IEEE-754 trick: stuff 52 random bits into a known
+        // exponent of 1.0, giving a uniform [1.0, 2.0); subtracting 1.0
+        // yields a uniform [0.0, 1.0) without any lossy `as f64` casts.
         let sign = if rng_state & 1 == 0 { 1.0 } else { -1.0 };
-        let exp = ((rng_state >> 1) % 600) as i32 - 300; // -300 to +299
-        let mantissa = ((rng_state >> 10) as f64) / (1u64 << 54) as f64;
+        let exp = i32::try_from((rng_state >> 1) % 600).expect("range mod 600 fits in i32") - 300;
+        let mantissa = f64::from_bits((rng_state >> 12) | 0x3FF0_0000_0000_0000) - 1.0;
         let val = sign * (1.0 + mantissa) * 10f64.powi(exp);
 
         // Skip if not finite (shouldn't happen with our construction, but be safe)
@@ -1251,7 +1254,9 @@ fn test_numbits_to_qnumber_utf8() {
 
     for _ in 0..1000 {
         rng_state = rng_state.wrapping_mul(6364136223846793005).wrapping_add(1);
-        let val = ((rng_state as f64) / (u64::MAX as f64)).mul_add(2e100, -1e100);
+        // Same IEEE-754 mantissa trick as above for a uniform [0.0, 1.0).
+        let unit = f64::from_bits((rng_state >> 12) | 0x3FF0_0000_0000_0000) - 1.0;
+        let val = unit.mul_add(2e100, -1e100);
         if val.is_finite() {
             ordered_vals.push(val);
         }

--- a/src/tests_stress.rs
+++ b/src/tests_stress.rs
@@ -1044,7 +1044,12 @@ fn test_concurrent_update_during_matching() {
         verified += 1;
     }
 
-    let events_per_sec = lines.len() as f64 / elapsed.as_secs_f64();
+    // Integer throughput: events × 1s / elapsed_ns. u128 leaves plenty of
+    // headroom for the multiplication and avoids any f64 conversion.
+    let events_per_sec = u128::try_from(lines.len())
+        .ok()
+        .and_then(|n| n.checked_mul(1_000_000_000))
+        .map_or(0, |numer| numer / elapsed.as_nanos().max(1));
     println!(
         "Concurrent update test: {events_per_sec:.0} events/sec, {total_matches} total matches, {sent} patterns added concurrently, {verified} verified"
     );
@@ -1122,7 +1127,7 @@ fn test_pattern_insertion_scales_linearly() {
         let _ = warmup.matches_for_event(br#"{"key": "warmup_0"}"#);
     }
 
-    let mut costs: Vec<(usize, f64)> = Vec::new();
+    let mut costs: Vec<(usize, u128)> = Vec::new();
 
     for &n in layers {
         let mut q = QuaminaBuilder::new()
@@ -1141,8 +1146,11 @@ fn test_pattern_insertion_scales_linearly() {
             matches.contains(&"p0".to_string()),
             "Pattern p0 should match after adding {n} patterns",
         );
-        let cost_per_pattern = elapsed.as_secs_f64() / n as f64;
-        costs.push((n, cost_per_pattern));
+        // Per-pattern cost in nanoseconds; integer math sidesteps any f64
+        // conversion. `n` is always >= 1 in this loop.
+        let cost_per_pattern_ns =
+            elapsed.as_nanos() / u128::try_from(n).expect("n is small and non-negative");
+        costs.push((n, cost_per_pattern_ns));
     }
 
     // Compare per-pattern cost between consecutive layers.
@@ -1151,19 +1159,26 @@ fn test_pattern_insertion_scales_linearly() {
     for i in 1..costs.len() {
         let (small_n, small_cost) = costs[i - 1];
         let (large_n, large_cost) = costs[i];
-        let ratio = large_cost / small_cost.max(1e-9);
+        // Equivalent to `large_cost / small_cost > 6.0` but in integer space.
+        // `small_cost.max(1)` guards against a zero-elapsed division on
+        // ultra-fast first iterations.
+        let denom = small_cost.max(1);
+        let too_steep = large_cost > denom.saturating_mul(6);
+        // Ratio expressed in tenths so we can print "5.4x" without f64.
+        let ratio_tenths = large_cost.saturating_mul(10) / denom;
+        let small_us_tenths = small_cost / 100; // ns → 0.1µs units
+        let large_us_tenths = large_cost / 100;
         assert!(
-            ratio < 6.0,
-            "Pattern insertion scales poorly between n={} and n={}: {:.1}x \
-             (n={}={:.4}ms/pattern, n={}={:.4}ms/pattern). \
+            !too_steep,
+            "Pattern insertion scales poorly between n={small_n} and n={large_n}: \
+             {}.{}x (n={small_n}={}.{}µs/pattern, n={large_n}={}.{}µs/pattern). \
              This suggests O(n²) regression.",
-            small_n,
-            large_n,
-            ratio,
-            small_n,
-            small_cost * 1000.0,
-            large_n,
-            large_cost * 1000.0,
+            ratio_tenths / 10,
+            ratio_tenths % 10,
+            small_us_tenths / 10,
+            small_us_tenths % 10,
+            large_us_tenths / 10,
+            large_us_tenths % 10,
         );
     }
 }


### PR DESCRIPTION
Final slice of the strict-clippy work from #94. Drops the four cast allows and `string_lit_as_bytes`, then fixes the fallout — `TryFrom` where the bound is real, integer-only arithmetic where it reads cleaner (PrunerStats rebuild ratio, example timing output, IPv6 parsing via `to_be_bytes`, IEEE-754 mantissa trick instead of `as f64` in the test RNG).

A few cleanups rolled in:

- `arena_index_u32` split into `state_count_u32` / `buffer_offset_u32`; flattened-buffer offsets aren't strictly bounded by state count and the original doc overstated that.
- `BYTE_CEILING_U8` constant so we stop sprinkling `BYTE_CEILING as u8`.
- Merge memo keys go from `(i32, i32)` with a `-1` sentinel to `(StateId, StateId)` — `StateId::NONE` already encoded that case.
- `flatten_json` unicode-escape emission consolidated into `read_unicode_escape` (`char::encode_utf8` for well-formed cases, documented WTF-8 fallback for lone low surrogates to match upstream Go). New test covers the fallback.
- Macros bounce events through a tiny `event_bytes` helper to dodge `string_lit_as_bytes`.
- `just check` now runs clippy with `--all-targets --all-features` so bench-only code gets linted; that caught two stale `as usize` casts in `benches/memory.rs`.

774 tests pass; clippy clean across all targets/features. No new unsafe, no recursion or pointer math, so no miri timeout concerns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)