### PR TITLE
test: loop/insertion-progress debug_asserts (#41)

### DIFF
--- a/examples/profile_negated.rs
+++ b/examples/profile_negated.rs
@@ -25,5 +25,5 @@ fn main() {
 
     let elapsed = start.elapsed();
     let ns_per_op = elapsed.as_nanos() / iterations;
-    eprintln!("{iterations} iterations in {elapsed:.2?} ({ns_per_op} ns/op)",);
+    eprintln!("{iterations} iterations in {elapsed:.2?} ({ns_per_op} ns/op)");
 }

--- a/src/automaton/sparse_set.rs
+++ b/src/automaton/sparse_set.rs
@@ -67,7 +67,9 @@ impl SparseSet {
         );
         self.dense[self.len] = id;
         self.sparse[id] = self.len;
+        let prev_len = self.len;
         self.len += 1;
+        debug_assert!(self.len > prev_len, "SparseSet::insert must advance len");
         true
     }
 

--- a/src/numbits.rs
+++ b/src/numbits.rs
@@ -85,6 +85,7 @@ pub(crate) fn to_q_number_stack(nb: u64) -> QNumberStack {
     let mut index = MAX_BYTES_IN_ENCODING - 1; // 10
 
     loop {
+        let prev = index;
         if nb & 0x7f != 0 {
             break;
         }
@@ -94,6 +95,7 @@ pub(crate) fn to_q_number_stack(nb: u64) -> QNumberStack {
             break;
         }
         index -= 1;
+        debug_assert!(index < prev, "to_q_number_stack: index must decrease");
     }
 
     // Content length (excluding prefix)
@@ -168,6 +170,7 @@ pub(crate) fn to_q_number(nb: u64) -> Vec<u8> {
     let mut index = max_content_bytes - 1;
 
     loop {
+        let prev = index;
         if nb & 0x7f != 0 {
             break;
         }
@@ -177,6 +180,7 @@ pub(crate) fn to_q_number(nb: u64) -> Vec<u8> {
             break;
         }
         index -= 1;
+        debug_assert!(index < prev, "to_q_number: index must decrease");
     }
 
     // Now fill in the byte encoding for the digits up to the last non-zero


### PR DESCRIPTION
Three places where cargo-mutants was timing out instead of catching mutations:

- `to_q_number` and `to_q_number_stack` in `numbits.rs`: mutations of
  `index -= 1` to `+= 1` / `*= 1` spin forever. A `debug_assert!` on
  loop progress turns the hang into an immediate panic.
- `SparseSet::insert` in `sparse_set.rs`: same story for `len += 1`.

Also removes a spurious trailing comma in `profile_negated.rs`.

No new tests — the existing suite already exercises these paths; the
asserts just make mutated builds fail fast instead of hanging.