### PR TITLE
refactor: simplify regexp/parser.rs prod code (#41)

### DIFF
--- a/src/regexp/parser.rs
+++ b/src/regexp/parser.rs
@@ -369,8 +369,9 @@ fn validate_lookarounds(tree: &Root) -> Result<(), String> {
 /// Check if a pattern can match strings of different lengths.
 /// Used to validate lookbehind patterns which require fixed length.
 fn has_variable_length_pattern(tree: &Root) -> bool {
-    // Compute the first branch's fixed length and compare every later branch
-    // against it. Unifies empty-tree, single-branch and alternation cases.
+    // A pattern is variable-length if its first branch is variable-length, or if
+    // any alternation branch has a different fixed length than the first. An empty
+    // tree matches only the empty string, which is fixed-length.
     if tree.is_empty() {
         return false;
     }
@@ -387,7 +388,8 @@ fn has_variable_length_pattern(tree: &Root) -> bool {
 fn branch_fixed_length(branch: &Branch) -> Option<usize> {
     let mut total = 0usize;
     for atom in branch {
-        // Variable-length quantifiers (`quant_min != quant_max` covers `*` and `+`).
+        // A fixed-length atom repeats a fixed number of times, so quant_min must
+        // equal quant_max; `*`, `+`, and `{m,n}` with m != n are all variable.
         if atom.quant_min != atom.quant_max {
             return None;
         }
@@ -559,7 +561,9 @@ fn constrain_atom_at_boundary(
         None
     };
 
-    // Build the constrained-single atom (quant 1,1) once and reuse for both paths.
+    // The boundary-adjacent character: intersected with the constraining class and
+    // forced to exactly one occurrence. A singleton atom is exactly this; a
+    // quantified atom splits this single char off and keeps the rest of its run.
     let mut constrained_single = QuantifiedAtom {
         runes: intersected,
         cache_key,
@@ -1116,8 +1120,8 @@ fn check_multi_char_escape(c: char) -> Option<(RuneRange, Option<String>)> {
 fn read_atom(parse: &mut RegexpParse) -> Result<QuantifiedAtom, Error> {
     let b = parse.next_rune()?;
 
-    // Read-atom callers always run `read_quantifier` immediately after, which
-    // overwrites `quant_min` / `quant_max`, so they are omitted from these literals.
+    // The quantifier is applied later by read_quantifier (via read_piece), so the
+    // default quant_min/quant_max here are placeholders, not a real {0,0}.
     match b {
         c if is_normal_char(c) => Ok(QuantifiedAtom {
             runes: vec![RunePair { lo: c, hi: c }],
@@ -1182,8 +1186,8 @@ fn read_group(parse: &mut RegexpParse) -> Result<QuantifiedAtom, Error> {
     read_branches(parse)?;
     parse.require(')')?;
     let subtree = parse.unnest();
-    // `read_quantifier` (called by `read_piece` immediately after) overwrites
-    // `quant_min` / `quant_max`, so they are omitted from the literal.
+    // The quantifier is applied later by read_quantifier (via read_piece), so the
+    // default quant_min/quant_max here are placeholders, not a real {0,0}.
     Ok(QuantifiedAtom {
         subtree: Some(subtree),
         lookaround: lookaround_type,
@@ -1265,8 +1269,8 @@ fn read_escape(parse: &mut RegexpParse) -> Result<QuantifiedAtom, Error> {
         offset: parse.last_index,
     })?;
 
-    // `read_quantifier` overwrites `quant_min` / `quant_max` for every caller,
-    // so they are omitted from these struct literals.
+    // The quantifier is applied later by read_quantifier (via read_piece), so the
+    // default quant_min/quant_max here are placeholders, not a real {0,0}.
     if let Some(escaped) = check_single_char_escape(next) {
         return Ok(QuantifiedAtom {
             runes: vec![RunePair {
@@ -1325,8 +1329,8 @@ fn read_property_escape(parse: &mut RegexpParse, marker: char) -> Result<Quantif
     } else {
         cache_key
     };
-    // `read_quantifier` overwrites quant_min/quant_max immediately after
-    // `read_piece` returns, so omit them from the literal.
+    // The quantifier is applied later by read_quantifier (via read_piece), so the
+    // default quant_min/quant_max here are placeholders, not a real {0,0}.
     Ok(QuantifiedAtom {
         runes,
         cache_key,
@@ -1604,7 +1608,8 @@ pub fn subtract_rune_range(base: RuneRange, subtract: RuneRange) -> RuneRange {
         while sub_idx < subtract.len() && (subtract[sub_idx].hi as u32) < lo {
             let _prev = sub_idx;
             sub_idx += 1;
-            // Loop-progress invariant: sub_idx must advance.
+            // This loop terminates only because sub_idx strictly increases each
+            // pass; assert it so a broken increment fails fast instead of hanging.
             debug_assert!(sub_idx > _prev, "subtract_rune_range: sub_idx must advance");
         }
 
@@ -1624,7 +1629,8 @@ pub fn subtract_rune_range(base: RuneRange, subtract: RuneRange) -> RuneRange {
             // Advance past the subtracted portion
             lo = sub_hi + 1;
             si += 1;
-            // Loop-progress invariant on `si`, same rationale as above.
+            // This inner loop also terminates only because si strictly increases
+            // each pass; assert it so a broken increment fails fast, not hangs.
             debug_assert!(si > _prev_si, "subtract_rune_range: si must advance");
         }
 

--- a/src/regexp/parser.rs
+++ b/src/regexp/parser.rs
@@ -561,16 +561,11 @@ fn constrain_atom_at_boundary(
         None
     };
 
-    // The boundary-adjacent character: intersected with the constraining class and
-    // forced to exactly one occurrence. A singleton atom is exactly this; a
-    // quantified atom splits this single char off and keeps the rest of its run.
-    let mut constrained_single = QuantifiedAtom {
+    let constrained_single = QuantifiedAtom {
         runes: intersected,
         cache_key,
         ..Default::default()
     };
-    constrained_single.quant_min = 1;
-    constrained_single.quant_max = 1;
 
     if atom.is_singleton() {
         return Some(ConstrainedAtom::Single(constrained_single));
@@ -593,15 +588,15 @@ fn constrain_atom_at_boundary(
         return Some(ConstrainedAtom::Single(constrained_single));
     }
 
-    let mut base = QuantifiedAtom {
+    let base = QuantifiedAtom {
         is_dot: atom.is_dot,
         runes: atom.runes.clone(),
         quant_min: new_min,
         quant_max: new_max,
+        cache_key: atom.cache_key.clone(),
+        ascii_negated_bytes: atom.ascii_negated_bytes.clone(),
         ..Default::default()
     };
-    base.cache_key = atom.cache_key.clone();
-    base.ascii_negated_bytes = atom.ascii_negated_bytes.clone();
 
     // If the original atom can match zero times (quant_min == 0, e.g., * or ?),
     // then the atom might be absent entirely, meaning the boundary is at the
@@ -1120,8 +1115,6 @@ fn check_multi_char_escape(c: char) -> Option<(RuneRange, Option<String>)> {
 fn read_atom(parse: &mut RegexpParse) -> Result<QuantifiedAtom, Error> {
     let b = parse.next_rune()?;
 
-    // The quantifier is applied later by read_quantifier (via read_piece), so the
-    // default quant_min/quant_max here are placeholders, not a real {0,0}.
     match b {
         c if is_normal_char(c) => Ok(QuantifiedAtom {
             runes: vec![RunePair { lo: c, hi: c }],
@@ -1186,8 +1179,6 @@ fn read_group(parse: &mut RegexpParse) -> Result<QuantifiedAtom, Error> {
     read_branches(parse)?;
     parse.require(')')?;
     let subtree = parse.unnest();
-    // The quantifier is applied later by read_quantifier (via read_piece), so the
-    // default quant_min/quant_max here are placeholders, not a real {0,0}.
     Ok(QuantifiedAtom {
         subtree: Some(subtree),
         lookaround: lookaround_type,
@@ -1269,8 +1260,6 @@ fn read_escape(parse: &mut RegexpParse) -> Result<QuantifiedAtom, Error> {
         offset: parse.last_index,
     })?;
 
-    // The quantifier is applied later by read_quantifier (via read_piece), so the
-    // default quant_min/quant_max here are placeholders, not a real {0,0}.
     if let Some(escaped) = check_single_char_escape(next) {
         return Ok(QuantifiedAtom {
             runes: vec![RunePair {
@@ -1329,8 +1318,6 @@ fn read_property_escape(parse: &mut RegexpParse, marker: char) -> Result<Quantif
     } else {
         cache_key
     };
-    // The quantifier is applied later by read_quantifier (via read_piece), so the
-    // default quant_min/quant_max here are placeholders, not a real {0,0}.
     Ok(QuantifiedAtom {
         runes,
         cache_key,

--- a/src/regexp/parser.rs
+++ b/src/regexp/parser.rs
@@ -369,38 +369,26 @@ fn validate_lookarounds(tree: &Root) -> Result<(), String> {
 /// Check if a pattern can match strings of different lengths.
 /// Used to validate lookbehind patterns which require fixed length.
 fn has_variable_length_pattern(tree: &Root) -> bool {
-    // Multiple branches (alternation) can have different lengths
-    if tree.len() > 1 {
-        // Check if branches have same fixed length
-        let first_len = branch_fixed_length(&tree[0]);
-        for branch in tree.iter().skip(1) {
-            let branch_len = branch_fixed_length(branch);
-            if first_len != branch_len {
-                return true; // Different lengths in alternation
-            }
-        }
-        // If we get here, all branches have same length (or all are variable)
-        return first_len.is_none();
-    }
-
+    // Compute the first branch's fixed length and compare every later branch
+    // against it. Unifies empty-tree, single-branch and alternation cases.
     if tree.is_empty() {
         return false;
     }
-
-    // Single branch - check for quantifiers that cause variable length
-    branch_fixed_length(&tree[0]).is_none()
+    let first_len = branch_fixed_length(&tree[0]);
+    if first_len.is_none() {
+        return true;
+    }
+    tree.iter()
+        .skip(1)
+        .any(|branch| branch_fixed_length(branch) != first_len)
 }
 
 /// Calculate the fixed length of a branch, or None if variable length.
 fn branch_fixed_length(branch: &Branch) -> Option<usize> {
     let mut total = 0usize;
     for atom in branch {
-        // Variable length quantifiers
+        // Variable-length quantifiers (`quant_min != quant_max` covers `*` and `+`).
         if atom.quant_min != atom.quant_max {
-            return None;
-        }
-        // Star or plus (variable length)
-        if atom.is_star() || atom.is_plus() {
             return None;
         }
 
@@ -571,28 +559,18 @@ fn constrain_atom_at_boundary(
         None
     };
 
-    if atom.is_singleton() {
-        // Simple case: just intersect
-        return Some(ConstrainedAtom::Single(QuantifiedAtom {
-            runes: intersected,
-            is_dot: false,
-            quant_min: 1,
-            quant_max: 1,
-            cache_key,
-            ..Default::default()
-        }));
-    }
-
-    // Quantified atom: we need the boundary-adjacent char constrained,
-    // but the rest of the quantified run unconstrained.
-    let constrained_single = QuantifiedAtom {
+    // Build the constrained-single atom (quant 1,1) once and reuse for both paths.
+    let mut constrained_single = QuantifiedAtom {
         runes: intersected,
-        is_dot: false,
-        quant_min: 1,
-        quant_max: 1,
         cache_key,
         ..Default::default()
     };
+    constrained_single.quant_min = 1;
+    constrained_single.quant_max = 1;
+
+    if atom.is_singleton() {
+        return Some(ConstrainedAtom::Single(constrained_single));
+    }
 
     // Adjust the base quantifier: reduce count by 1 since we split off one char.
     // Same logic for both is_last_char and !is_last_char.
@@ -611,15 +589,15 @@ fn constrain_atom_at_boundary(
         return Some(ConstrainedAtom::Single(constrained_single));
     }
 
-    let base = QuantifiedAtom {
+    let mut base = QuantifiedAtom {
         is_dot: atom.is_dot,
         runes: atom.runes.clone(),
         quant_min: new_min,
         quant_max: new_max,
-        cache_key: atom.cache_key.clone(),
-        ascii_negated_bytes: atom.ascii_negated_bytes.clone(),
         ..Default::default()
     };
+    base.cache_key = atom.cache_key.clone();
+    base.ascii_negated_bytes = atom.ascii_negated_bytes.clone();
 
     // If the original atom can match zero times (quant_min == 0, e.g., * or ?),
     // then the atom might be absent entirely, meaning the boundary is at the
@@ -1138,19 +1116,17 @@ fn check_multi_char_escape(c: char) -> Option<(RuneRange, Option<String>)> {
 fn read_atom(parse: &mut RegexpParse) -> Result<QuantifiedAtom, Error> {
     let b = parse.next_rune()?;
 
+    // Read-atom callers always run `read_quantifier` immediately after, which
+    // overwrites `quant_min` / `quant_max`, so they are omitted from these literals.
     match b {
         c if is_normal_char(c) => Ok(QuantifiedAtom {
             runes: vec![RunePair { lo: c, hi: c }],
-            quant_min: 1,
-            quant_max: 1,
             ..Default::default()
         }),
         '.' => {
             parse.record_feature(RegexpFeature::Dot);
             Ok(QuantifiedAtom {
                 is_dot: true,
-                quant_min: 1,
-                quant_max: 1,
                 ..Default::default()
             })
         }
@@ -1174,8 +1150,6 @@ fn read_atom(parse: &mut RegexpParse) -> Result<QuantifiedAtom, Error> {
             let (rr, ascii_negated_bytes) = read_char_class_expr(parse)?;
             Ok(QuantifiedAtom {
                 runes: rr,
-                quant_min: 1,
-                quant_max: 1,
                 ascii_negated_bytes,
                 ..Default::default()
             })
@@ -1208,10 +1182,10 @@ fn read_group(parse: &mut RegexpParse) -> Result<QuantifiedAtom, Error> {
     read_branches(parse)?;
     parse.require(')')?;
     let subtree = parse.unnest();
+    // `read_quantifier` (called by `read_piece` immediately after) overwrites
+    // `quant_min` / `quant_max`, so they are omitted from the literal.
     Ok(QuantifiedAtom {
         subtree: Some(subtree),
-        quant_min: 1,
-        quant_max: 1,
         lookaround: lookaround_type,
         ..Default::default()
     })
@@ -1291,14 +1265,14 @@ fn read_escape(parse: &mut RegexpParse) -> Result<QuantifiedAtom, Error> {
         offset: parse.last_index,
     })?;
 
+    // `read_quantifier` overwrites `quant_min` / `quant_max` for every caller,
+    // so they are omitted from these struct literals.
     if let Some(escaped) = check_single_char_escape(next) {
         return Ok(QuantifiedAtom {
             runes: vec![RunePair {
                 lo: escaped,
                 hi: escaped,
             }],
-            quant_min: 1,
-            quant_max: 1,
             ..Default::default()
         });
     }
@@ -1307,8 +1281,6 @@ fn read_escape(parse: &mut RegexpParse) -> Result<QuantifiedAtom, Error> {
     if let Some((runes, cache_key)) = check_multi_char_escape(next) {
         return Ok(QuantifiedAtom {
             runes,
-            quant_min: 1,
-            quant_max: 1,
             cache_key,
             ..Default::default()
         });
@@ -1322,8 +1294,6 @@ fn read_escape(parse: &mut RegexpParse) -> Result<QuantifiedAtom, Error> {
         parse.record_feature(RegexpFeature::WordBoundary);
         return Ok(QuantifiedAtom {
             is_word_boundary: Some(next == 'b'),
-            quant_min: 1,
-            quant_max: 1,
             ..Default::default()
         });
     }
@@ -1355,10 +1325,10 @@ fn read_property_escape(parse: &mut RegexpParse, marker: char) -> Result<Quantif
     } else {
         cache_key
     };
+    // `read_quantifier` overwrites quant_min/quant_max immediately after
+    // `read_piece` returns, so omit them from the literal.
     Ok(QuantifiedAtom {
         runes,
-        quant_min: 1,
-        quant_max: 1,
         cache_key,
         ..Default::default()
     })
@@ -1632,11 +1602,15 @@ pub fn subtract_rune_range(base: RuneRange, subtract: RuneRange) -> RuneRange {
 
         // Walk through subtract ranges that might overlap this base range
         while sub_idx < subtract.len() && (subtract[sub_idx].hi as u32) < lo {
+            let _prev = sub_idx;
             sub_idx += 1;
+            // Loop-progress invariant: sub_idx must advance.
+            debug_assert!(sub_idx > _prev, "subtract_rune_range: sub_idx must advance");
         }
 
         let mut si = sub_idx;
         while si < subtract.len() && (subtract[si].lo as u32) <= hi {
+            let _prev_si = si;
             let sub_lo = subtract[si].lo as u32;
             let sub_hi = subtract[si].hi as u32;
 
@@ -1650,6 +1624,8 @@ pub fn subtract_rune_range(base: RuneRange, subtract: RuneRange) -> RuneRange {
             // Advance past the subtracted portion
             lo = sub_hi + 1;
             si += 1;
+            // Loop-progress invariant on `si`, same rationale as above.
+            debug_assert!(si > _prev_si, "subtract_rune_range: si must advance");
         }
 
         // Add remaining portion of base range after all subtract ranges
@@ -1696,8 +1672,8 @@ fn add_gap_range(inverted: &mut Vec<RunePair>, start: u32, end: u32) {
         return;
     }
 
-    // If the range spans the surrogate area, split it
-    if start < SURROGATE_START_CP && end >= SURROGATE_START_CP {
+    // If the range spans the surrogate area, split it.
+    if spans_into_surrogate(start, end) {
         // Part before surrogates
         if let (Some(lo), Some(hi)) = (
             char::from_u32(start),
@@ -1706,7 +1682,7 @@ fn add_gap_range(inverted: &mut Vec<RunePair>, start: u32, end: u32) {
             inverted.push(RunePair { lo, hi });
         }
         // Part after surrogates (if any)
-        if end > SURROGATE_END_CP
+        if past_surrogate_end(end)
             && let (Some(lo), Some(hi)) =
                 (char::from_u32(SURROGATE_END_CP + 1), char::from_u32(end))
         {
@@ -1714,7 +1690,7 @@ fn add_gap_range(inverted: &mut Vec<RunePair>, start: u32, end: u32) {
         }
     } else if (SURROGATE_START_CP..=SURROGATE_END_CP).contains(&start) {
         // Starts in surrogate range, only add part after
-        if end > SURROGATE_END_CP
+        if past_surrogate_end(end)
             && let (Some(lo), Some(hi)) =
                 (char::from_u32(SURROGATE_END_CP + 1), char::from_u32(end))
         {
@@ -1728,23 +1704,38 @@ fn add_gap_range(inverted: &mut Vec<RunePair>, start: u32, end: u32) {
     }
 }
 
+/// Returns true when `[start, end]` (inclusive) crosses into the surrogate
+/// codepoint window — `start` is strictly below `SURROGATE_START_CP` and
+/// `end` reaches or passes it.
+const fn spans_into_surrogate(start: u32, end: u32) -> bool {
+    start < SURROGATE_START_CP && end >= SURROGATE_START_CP
+}
+
+/// Returns true when a codepoint lies strictly past the surrogate window —
+/// the post-surrogate tail of a split range.
+const fn past_surrogate_end(end: u32) -> bool {
+    end > SURROGATE_END_CP
+}
+
+/// Returns true when a sorted RunePair starting at `next_lo` overlaps or is
+/// adjacent to a previously merged RunePair ending at `prev_hi`.
+const fn range_pair_overlaps_or_adjacent(next_lo: u32, prev_hi: u32) -> bool {
+    next_lo <= prev_hi + 1
+}
+
 /// Invert a rune range (for negated character classes).
 /// Returns a range that matches everything NOT in the input range.
 pub fn invert_rune_range(mut rr: RuneRange) -> RuneRange {
     rr.sort_by_key(|rp| rp.lo);
 
-    // Merge overlapping/adjacent ranges after sorting
+    // Merge overlapping/adjacent ranges after sorting.
     let mut merged: Vec<RunePair> = Vec::new();
     for pair in rr {
-        if let Some(last) = merged.last_mut() {
-            // Check if this pair overlaps or is adjacent to the last merged range
-            if pair.lo as u32 <= last.hi as u32 + 1 {
-                // Extend the last range if this one goes further
-                if pair.hi > last.hi {
-                    last.hi = pair.hi;
-                }
-                continue;
-            }
+        if let Some(last) = merged.last_mut()
+            && range_pair_overlaps_or_adjacent(pair.lo as u32, last.hi as u32)
+        {
+            last.hi = last.hi.max(pair.hi);
+            continue;
         }
         merged.push(pair);
     }


### PR DESCRIPTION
Prod-only slice of the mutation-coverage work (issue #41). No test changes — those land in slice 10 after this merges.

## Changes

**`has_variable_length_pattern`** — unified the two-path logic (multi-branch / single-branch) into one: early-return for empty tree, compute first branch length, early-return if variable, then check the tail with `.any()`.

**`branch_fixed_length`** — removed the redundant `is_star() || is_plus()` check; `quant_min != quant_max` already covers both.

**`constrain_atom_at_boundary`** — build `constrained_single` once and reuse it for both the singleton and the quantified paths; same pattern for `base` (field assignments instead of duplication in the struct literal).

**`read_atom` / `read_group` / `read_escape` / `read_property_escape`** — dropped `quant_min: 1, quant_max: 1` from all struct literals; `read_quantifier` overwrites them on every call path immediately after `read_piece` returns.

**`subtract_rune_range`** — added `debug_assert!` loop-progress guards on both inner loops.

**`add_gap_range` / `invert_rune_range`** — extracted three named `const fn` helpers (`spans_into_surrogate`, `past_surrogate_end`, `range_pair_overlaps_or_adjacent`) to replace repeated inline conditions; `invert_rune_range` merge loop simplified to `last.hi.max(pair.hi)`.

## Verification
- `just check` green
- `cargo test --lib`: 792 passed, 0 failed