### PR TITLE
fix: skip the ~i shell-cache test under Miri

### DIFF
--- a/src/regexp/nfa.rs
+++ b/src/regexp/nfa.rs
@@ -896,21 +896,18 @@ mod tests {
         assert!(intersects_surrogate(0, 0xFFFF));
     }
 
-    #[test]
-    fn test_clear_fa_shell_cache_drops_entries() {
-        // Populate the per-thread cache by building a regex with a rune range,
-        // then verify that `clear_fa_shell_cache` actually empties it.
+    // Populate the per-thread shell cache by building a cache-keyed regex, then
+    // verify `clear_fa_shell_cache` empties it. Shared by the native and
+    // Miri-friendly tests, which differ only in the size of the cached category.
+    fn verify_shell_cache_populate_then_clear(pattern: &str) {
         clear_fa_shell_cache();
         assert_eq!(fa_shell_cache_size(), 0);
-        // `~i` is the multi-char escape for the large Unicode identifier
-        // category that carries a `cache_key`, routing the build through
-        // the shell cache.
-        let root = crate::regexp::parse_regexp("~i").unwrap();
+        let root = crate::regexp::parse_regexp(pattern).unwrap();
         let _ = make_regexp_nfa_arena(root);
         let populated = fa_shell_cache_size();
         assert!(
             populated > 0,
-            "building a rune-range regex must populate the cache"
+            "building a cache-keyed regex must populate the cache"
         );
         clear_fa_shell_cache();
         assert_eq!(
@@ -918,6 +915,24 @@ mod tests {
             0,
             "clear_fa_shell_cache must drop all entries"
         );
+    }
+
+    // MIRI SKIP RATIONALE: `~i` is the XML-name-start Unicode category (~700
+    // rune ranges); building its NFA takes ~58 min under Miri. Coverage: the
+    // Miri-friendly variant below drives the same cache populate/clear path
+    // with the tiny `~p{Cc}` (control-char) category.
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_clear_fa_shell_cache_drops_entries() {
+        verify_shell_cache_populate_then_clear("~i");
+    }
+
+    /// Miri-friendly version — `~p{Cc}` is a two-range cache-keyed category, so
+    /// the cache lifecycle is exercised without the large `~i` NFA build.
+    #[cfg(miri)]
+    #[test]
+    fn test_clear_fa_shell_cache_drops_entries_miri_friendly() {
+        verify_shell_cache_populate_then_clear("~p{Cc}");
     }
 
     #[test]


### PR DESCRIPTION
## Problem
`regexp::nfa::tests::test_clear_fa_shell_cache_drops_entries` builds the NFA
for `~i` (the ~700-range XML-name-start Unicode category). Native it runs in
~0.2s, but under Miri it takes **~58 min** (locally measured: 3482s vs 0.89s
for a neighbouring test). That blows past the 30-min miri CI cap, cancelling
the job — the miri check has been red since this test landed in #106 and on
every branch cut afterward (e.g. the #107 run).

## Fix
- Mark the heavy test `#[cfg_attr(miri, ignore)]` (keeps full native coverage).
- Add a `#[cfg(miri)]` variant that drives the same cache populate/clear path
  via `~p{Cc}` — a two-range category that finishes in ~11s under Miri.
- Factor the shared assertions into a helper; the two tests differ only by the
  cached category.

Matches the existing `_miri_friendly` pattern in `numbits.rs` / `tests_stress.rs`.

## Verification
- Native: `cargo test --lib` green; `just check` clean.
- Miri (`nightly-2026-01-26`): heavy test `ignored`, `~p{Cc}` variant passes
  in 11.3s.