### PR TITLE
fix: flaky no_alloc_nfa_step parallel allocator race

### DIFF
--- a/tests/no_alloc_nfa_step.rs
+++ b/tests/no_alloc_nfa_step.rs
@@ -13,6 +13,15 @@
 //! The harness lives in its own integration-test binary so the global
 //! allocator is scoped to this file alone — it does not perturb the unit
 //! test allocator.
+//!
+//! The counter and its enable flag are process-global, and the allocator sees
+//! allocations from every thread. Both measured scenarios therefore live in a
+//! single `#[test]` function and run sequentially: that keeps exactly one test
+//! thread alive in this binary, so no sibling test's setup or the harness's
+//! result reporting can allocate while a counting window is open. (When the
+//! two scenarios were separate `#[test]`s, `cargo test` ran them in parallel
+//! and their windows interleaved, miscounting one test's allocations against
+//! the other.)
 
 #![allow(unsafe_code)]
 
@@ -60,13 +69,12 @@ unsafe impl GlobalAlloc for CountingAlloc {
 #[global_allocator]
 static GLOBAL: CountingAlloc = CountingAlloc;
 
-#[test]
-// Miri intercepts the global allocator and runs the interpreter ~100x slower,
-// so allocation counts aren't representative of release-mode native code and
-// 1000 traversals would risk the CI timeout. Memory safety of the stepping
-// path is covered by the unit tests in `src/automaton/arena.rs`.
-#[cfg_attr(miri, ignore)]
-fn traverse_arena_nfa_is_alloc_free_in_steady_state() {
+/// Builds the shellstyle `A*` FA, warms the reusable buffers, then counts the
+/// allocations performed by 1000 steady-state traversals of `value`.
+///
+/// `expect_match` asserts the warmup behaved as intended for the chosen value,
+/// catching a broken setup before it masquerades as an allocation result.
+fn count_steady_state_allocs(value: &[u8], expect_match: bool) -> usize {
     // Shellstyle "A*" gives us an FA with a junction, a spinner with a 256-byte
     // self-loop, an epsilon transition, and a value-terminator endpoint — i.e.
     // every interesting code path inside `traverse_arena_nfa`.
@@ -75,20 +83,17 @@ fn traverse_arena_nfa_is_alloc_free_in_steady_state() {
     arena.precompute_epsilon_closures();
     arena.flatten_tables();
 
-    // The traversal expects the value to end with the arena's value terminator.
-    let mut value: Vec<u8> = b"ALICE_IN_WONDERLAND_AAAAAAAAAAAA".to_vec();
-    value.push(ARENA_VALUE_TERMINATOR);
-
     let mut bufs = NfaBuffers::with_capacity();
 
     // Warmup. The first few traversals push into the internal Vecs / HashSets
     // inside `NfaBuffers`, growing them to their working capacity. Sixteen
     // iterations is overkill for this small FA but cheap insurance.
     for _ in 0..16 {
-        traverse_arena_nfa(&arena, start, &value, &mut bufs);
-        assert!(
+        traverse_arena_nfa(&arena, start, value, &mut bufs);
+        assert_eq!(
             !bufs.transitions.is_empty(),
-            "warmup match failed — pattern should match the value"
+            expect_match,
+            "warmup produced an unexpected match result — test setup is broken"
         );
     }
 
@@ -96,49 +101,38 @@ fn traverse_arena_nfa_is_alloc_free_in_steady_state() {
     ALLOCS.store(0, Ordering::Relaxed);
     COUNTING_ENABLED.store(1, Ordering::Relaxed);
     for _ in 0..1000 {
-        traverse_arena_nfa(&arena, start, &value, &mut bufs);
+        traverse_arena_nfa(&arena, start, value, &mut bufs);
     }
     COUNTING_ENABLED.store(0, Ordering::Relaxed);
-    let allocs = ALLOCS.load(Ordering::Relaxed);
-
-    assert_eq!(
-        allocs, 0,
-        "traverse_arena_nfa allocated {allocs} time(s) across 1000 steady-state matches; the inner NFA step is supposed to be allocation-free (upstream Go e33139f equivalent)"
-    );
+    ALLOCS.load(Ordering::Relaxed)
 }
 
-/// A non-matching value still exercises every branch of the stepping loop —
-/// in fact more of them, because the pattern's spinner state has to absorb
-/// every byte rather than terminating early. Same allocation guarantee.
 #[test]
+// Miri intercepts the global allocator and runs the interpreter ~100x slower,
+// so allocation counts aren't representative of release-mode native code and
+// 1000 traversals would risk the CI timeout. Memory safety of the stepping
+// path is covered by the unit tests in `src/automaton/arena.rs`.
 #[cfg_attr(miri, ignore)]
-fn traverse_arena_nfa_no_match_is_alloc_free_in_steady_state() {
-    let next_field = Arc::new(FieldMatcher::new());
-    let (mut arena, start) = make_shellstyle_arena_fa(b"A*", next_field);
-    arena.precompute_epsilon_closures();
-    arena.flatten_tables();
-
-    // Starts with 'B', so no match — the FA dies out on the first byte.
-    let mut value: Vec<u8> = b"BOB_NEVER_STARTS_WITH_A".to_vec();
-    value.push(ARENA_VALUE_TERMINATOR);
-
-    let mut bufs = NfaBuffers::with_capacity();
-
-    for _ in 0..16 {
-        traverse_arena_nfa(&arena, start, &value, &mut bufs);
-        assert!(bufs.transitions.is_empty(), "warmup unexpectedly matched");
-    }
-
-    ALLOCS.store(0, Ordering::Relaxed);
-    COUNTING_ENABLED.store(1, Ordering::Relaxed);
-    for _ in 0..1000 {
-        traverse_arena_nfa(&arena, start, &value, &mut bufs);
-    }
-    COUNTING_ENABLED.store(0, Ordering::Relaxed);
-    let allocs = ALLOCS.load(Ordering::Relaxed);
-
+fn traverse_arena_nfa_is_alloc_free_in_steady_state() {
+    // Matching value: ends with the arena's value terminator and runs the
+    // spinner to a successful endpoint.
+    let mut matching: Vec<u8> = b"ALICE_IN_WONDERLAND_AAAAAAAAAAAA".to_vec();
+    matching.push(ARENA_VALUE_TERMINATOR);
+    let match_allocs = count_steady_state_allocs(&matching, true);
     assert_eq!(
-        allocs, 0,
-        "traverse_arena_nfa allocated {allocs} time(s) across 1000 no-match traversals"
+        match_allocs, 0,
+        "traverse_arena_nfa allocated {match_allocs} time(s) across 1000 steady-state matches; the inner NFA step is supposed to be allocation-free (upstream Go e33139f equivalent)"
+    );
+
+    // Non-matching value: starts with 'B', so the FA dies out on the first
+    // byte. This still exercises every branch of the stepping loop — in fact
+    // more of them, because the spinner has to absorb every byte rather than
+    // terminating early. Same allocation guarantee.
+    let mut no_match: Vec<u8> = b"BOB_NEVER_STARTS_WITH_A".to_vec();
+    no_match.push(ARENA_VALUE_TERMINATOR);
+    let no_match_allocs = count_steady_state_allocs(&no_match, false);
+    assert_eq!(
+        no_match_allocs, 0,
+        "traverse_arena_nfa allocated {no_match_allocs} time(s) across 1000 no-match traversals"
     );
 }


### PR DESCRIPTION
`tests/no_alloc_nfa_step.rs` failed intermittently on CI (`traverse_arena_nfa allocated 2 time(s)...`) even though the stepping path itself is fine.

The two `#[test]`s share the process-global `ALLOCS` counter and `COUNTING_ENABLED` flag, but `cargo test` runs them in parallel and the allocator sees every thread. When their counting windows interleaved, one test's setup/warmup allocations got charged to the other's window — hence the small nonzero counts that only showed up under CI's slower, contended scheduling. I reproduced it locally by running the test binary under CPU load.

Fix: merge the match and no-match scenarios into a single test that runs them sequentially through a shared helper, so only one test thread is ever live in the binary and nothing else can allocate while a window is open. Verified 0 failures in 300 runs under the same CPU load that previously broke it reliably.