### PR TITLE
refactor: simplify flatten_json.rs prod code (#41)

### DIFF
--- a/src/flatten_json.rs
+++ b/src/flatten_json.rs
@@ -206,6 +206,44 @@ struct FlattenContext<'a, 'b> {
     array_count: i32,
 }
 
+/// Returns true when the flattener is currently inside a skipped subtree
+/// (i.e. a member whose path is NOT in the segments tree).
+const fn is_in_skipped_subtree(skipping: i32) -> bool {
+    skipping > 0
+}
+
+/// Returns true when we should capture the value at the current member —
+/// only when we're at the top of a tree-tracked path (skipping == 0) AND
+/// the member name was in the segments tree.
+const fn should_capture_value(skipping: i32, member_is_used: bool) -> bool {
+    skipping == 0 && member_is_used
+}
+
+/// Returns true when `event[index]` exists AND is an ASCII digit.
+#[inline]
+fn at_digit(event: &[u8], index: usize) -> bool {
+    index < event.len() && event[index].is_ascii_digit()
+}
+
+/// Returns true when `event[index]` exists AND matches `target`.
+#[inline]
+fn at_byte(event: &[u8], index: usize, target: u8) -> bool {
+    index < event.len() && event[index] == target
+}
+
+/// Returns true when `event[index..]` starts with a `\uXXXX` escape (six
+/// bytes: backslash, `u`, four hex digits).
+#[inline]
+fn has_unicode_escape_at(event: &[u8], index: usize) -> bool {
+    index + 5 < event.len() && event[index] == b'\\' && event[index + 1] == b'u'
+}
+
+/// Returns the byte one position past `index`, if any.
+#[inline]
+fn peek_next_byte(event: &[u8], index: usize) -> Option<u8> {
+    event.get(index + 1).copied()
+}
+
 impl<'a> FlattenContext<'a, '_> {
     /// Push a field to the storage, transmuting the lifetime.
     #[inline]
@@ -226,6 +264,7 @@ impl<'a> FlattenContext<'a, '_> {
 
         // Find the opening brace
         loop {
+            let _prev_outer = self.index;
             let ch = self.ch();
             if ch == b'{' {
                 match self.read_object(tree) {
@@ -236,6 +275,7 @@ impl<'a> FlattenContext<'a, '_> {
                 // Eat trailing whitespace
                 self.index += 1;
                 while self.index < self.event.len() {
+                    let _prev = self.index;
                     let ch = self.event[self.index];
                     if !is_whitespace(ch) {
                         return Err(self.error(&format!(
@@ -244,6 +284,7 @@ impl<'a> FlattenContext<'a, '_> {
                         )));
                     }
                     self.index += 1;
+                    debug_assert!(self.index > _prev, "flatten_impl trailing-ws must advance");
                 }
                 return Ok(());
             } else if is_whitespace(ch) {
@@ -254,6 +295,10 @@ impl<'a> FlattenContext<'a, '_> {
             } else {
                 return Err(self.error("not a JSON object"));
             }
+            debug_assert!(
+                self.index > _prev_outer,
+                "flatten_impl leading-ws must advance"
+            );
         }
     }
 
@@ -346,37 +391,37 @@ impl<'a> FlattenContext<'a, '_> {
 
                     match ch {
                         b'"' => {
-                            if self.skipping > 0 || !member_is_used {
-                                self.skip_string_value()?;
-                            } else {
+                            if should_capture_value(self.skipping, member_is_used) {
                                 val = Some(self.read_string_value()?);
+                            } else {
+                                self.skip_string_value()?;
                             }
                             is_leaf = true;
                         }
                         b't' => {
                             self.read_literal(b"true")?;
-                            if self.skipping == 0 && member_is_used {
+                            if should_capture_value(self.skipping, member_is_used) {
                                 val = Some(FieldValue::Borrowed(b"true"));
                             }
                             is_leaf = true;
                         }
                         b'f' => {
                             self.read_literal(b"false")?;
-                            if self.skipping == 0 && member_is_used {
+                            if should_capture_value(self.skipping, member_is_used) {
                                 val = Some(FieldValue::Borrowed(b"false"));
                             }
                             is_leaf = true;
                         }
                         b'n' => {
                             self.read_literal(b"null")?;
-                            if self.skipping == 0 && member_is_used {
+                            if should_capture_value(self.skipping, member_is_used) {
                                 val = Some(FieldValue::Borrowed(b"null"));
                             }
                             is_leaf = true;
                         }
                         b'-' | b'0'..=b'9' => {
                             let num_val = self.read_number()?;
-                            if self.skipping == 0 && member_is_used {
+                            if should_capture_value(self.skipping, member_is_used) {
                                 val = Some(num_val);
                                 is_number = true;
                             }
@@ -387,7 +432,7 @@ impl<'a> FlattenContext<'a, '_> {
                                 self.skipping += 1;
                             }
 
-                            if self.skipping > 0 {
+                            if is_in_skipped_subtree(self.skipping) {
                                 self.skip_block(b'[', b']')?;
                             } else {
                                 let array_tree =
@@ -405,7 +450,7 @@ impl<'a> FlattenContext<'a, '_> {
                                 self.skipping += 1;
                             }
 
-                            if self.skipping > 0 {
+                            if is_in_skipped_subtree(self.skipping) {
                                 self.skip_block(b'{', b'}')?;
                             } else if let Some(child_tree) = member_entry.and_then(|e| e.node()) {
                                 nodes_count = nodes_count.saturating_sub(1);
@@ -586,6 +631,7 @@ impl<'a> FlattenContext<'a, '_> {
     /// Skip remaining content until we exit the current object.
     fn leave_object(&mut self) -> Result<(), FlattenError> {
         while self.index < self.event.len() {
+            let _prev = self.index;
             let ch = self.event[self.index];
             match ch {
                 b'"' => self.skip_string_value()?,
@@ -597,6 +643,7 @@ impl<'a> FlattenContext<'a, '_> {
                 _ => {}
             }
             self.index += 1;
+            debug_assert!(self.index > _prev, "leave_object must advance index");
         }
         Err(FlattenError::Error(self.error("truncated block")))
     }
@@ -606,6 +653,7 @@ impl<'a> FlattenContext<'a, '_> {
         let mut level = 0;
 
         while self.index < self.event.len() {
+            let _prev = self.index;
             let ch = self.event[self.index];
 
             match ch {
@@ -621,6 +669,7 @@ impl<'a> FlattenContext<'a, '_> {
             }
 
             self.index += 1;
+            debug_assert!(self.index > _prev, "skip_block must advance index");
         }
 
         Err(FlattenError::Error(self.error("truncated block")))
@@ -631,15 +680,17 @@ impl<'a> FlattenContext<'a, '_> {
         self.step()?; // skip opening "
 
         while self.index < self.event.len() {
+            let _prev = self.index;
             let ch = self.event[self.index];
 
             // Handle escape sequences
-            if ch == b'\\' && self.index + 1 < self.event.len() {
-                let next = self.event[self.index + 1];
-                if next == b'\\' || next == b'"' {
-                    self.index += 2;
-                    continue;
-                }
+            if ch == b'\\'
+                && let Some(next) = peek_next_byte(self.event, self.index)
+                && (next == b'\\' || next == b'"')
+            {
+                self.index += 2;
+                debug_assert!(self.index > _prev, "skip_string_value escape must advance");
+                continue;
             }
 
             if ch == b'"' {
@@ -647,6 +698,7 @@ impl<'a> FlattenContext<'a, '_> {
             }
 
             self.index += 1;
+            debug_assert!(self.index > _prev, "skip_string_value must advance index");
         }
 
         Err(FlattenError::Error(self.error("truncated string")))
@@ -660,6 +712,7 @@ impl<'a> FlattenContext<'a, '_> {
         let start = self.index;
 
         while self.index < self.event.len() {
+            let _prev = self.index;
             let ch = self.event[self.index];
             if ch == b'"' {
                 return Ok(MemberName::Borrowed(&self.event[start..self.index]));
@@ -672,6 +725,7 @@ impl<'a> FlattenContext<'a, '_> {
                 ));
             }
             self.index += 1;
+            debug_assert!(self.index > _prev, "read_member_name must advance index");
         }
 
         Err(FlattenError::Error(self.error("premature end of event")))
@@ -687,6 +741,7 @@ impl<'a> FlattenContext<'a, '_> {
         name.extend_from_slice(&self.event[start..self.index]);
 
         while self.index < self.event.len() {
+            let _prev = self.index;
             let ch = self.event[self.index];
             if ch == b'"' {
                 return Ok(MemberName::Owned(name));
@@ -723,6 +778,10 @@ impl<'a> FlattenContext<'a, '_> {
                 name.push(ch);
             }
             self.index += 1;
+            debug_assert!(
+                self.index > _prev,
+                "read_member_name_with_escapes must advance index"
+            );
         }
 
         Err(FlattenError::Error(self.error("premature end of event")))
@@ -734,6 +793,7 @@ impl<'a> FlattenContext<'a, '_> {
         self.step()?; // skip opening "
 
         while self.index < self.event.len() {
+            let _prev = self.index;
             let ch = self.event[self.index];
             if ch == b'"' {
                 return Ok(FieldValue::Borrowed(&self.event[val_start..=self.index]));
@@ -746,6 +806,7 @@ impl<'a> FlattenContext<'a, '_> {
                 ));
             }
             self.index += 1;
+            debug_assert!(self.index > _prev, "read_string_value must advance index");
         }
 
         Err(FlattenError::Error(self.error("event truncated in string")))
@@ -761,6 +822,7 @@ impl<'a> FlattenContext<'a, '_> {
         val.extend_from_slice(&self.event[val_start + 1..self.index]);
 
         while self.index < self.event.len() {
+            let _prev = self.index;
             let ch = self.event[self.index];
             if ch == b'"' {
                 val.push(b'"');
@@ -797,6 +859,10 @@ impl<'a> FlattenContext<'a, '_> {
                 val.push(ch);
             }
             self.index += 1;
+            debug_assert!(
+                self.index > _prev,
+                "read_string_with_escapes must advance index"
+            );
         }
 
         Err(FlattenError::Error(self.error("premature end of event")))
@@ -829,10 +895,7 @@ impl<'a> FlattenContext<'a, '_> {
 
         if (0xD800..=0xDBFF).contains(&code) {
             // High surrogate — try to consume the matching low surrogate.
-            if self.index + 5 < self.event.len()
-                && self.event[self.index] == b'\\'
-                && self.event[self.index + 1] == b'u'
-            {
+            if has_unicode_escape_at(self.event, self.index) {
                 self.index += 2;
                 let low = self.read_hex_4()?;
                 if (0xDC00..=0xDFFF).contains(&low) {
@@ -907,46 +970,40 @@ impl<'a> FlattenContext<'a, '_> {
 
         // Integer part - must have at least one digit
         let digit_start = self.index;
-        while self.index < self.event.len() {
-            let ch = self.event[self.index];
-            if !ch.is_ascii_digit() {
-                break;
-            }
+        while at_digit(self.event, self.index) {
+            let _prev = self.index;
             self.index += 1;
+            debug_assert!(self.index > _prev, "read_number int digits must advance");
         }
 
         // Validate we read at least one digit
         if self.index == digit_start {
-            let ch = if self.index < self.event.len() {
-                self.event[self.index] as char
-            } else {
-                '?'
-            };
+            let ch = self.event.get(self.index).map_or('?', |&b| b as char);
             return Err(FlattenError::Error(
                 self.error(&format!("illegal character '{ch}' in number")),
             ));
         }
 
         // Fractional part
-        if self.index < self.event.len() && self.event[self.index] == b'.' {
+        if at_byte(self.event, self.index, b'.') {
             self.index += 1;
-            while self.index < self.event.len() && self.event[self.index].is_ascii_digit() {
+            while at_digit(self.event, self.index) {
+                let _prev = self.index;
                 self.index += 1;
+                debug_assert!(self.index > _prev, "read_number frac digits must advance");
             }
         }
 
         // Exponent
-        if self.index < self.event.len()
-            && (self.event[self.index] == b'e' || self.event[self.index] == b'E')
-        {
+        if at_byte(self.event, self.index, b'e') || at_byte(self.event, self.index, b'E') {
             self.index += 1;
-            if self.index < self.event.len()
-                && (self.event[self.index] == b'+' || self.event[self.index] == b'-')
-            {
+            if at_byte(self.event, self.index, b'+') || at_byte(self.event, self.index, b'-') {
                 self.index += 1;
             }
-            while self.index < self.event.len() && self.event[self.index].is_ascii_digit() {
+            while at_digit(self.event, self.index) {
+                let _prev = self.index;
                 self.index += 1;
+                debug_assert!(self.index > _prev, "read_number exp digits must advance");
             }
         }
 
@@ -985,7 +1042,13 @@ impl<'a> FlattenContext<'a, '_> {
 
     /// Enter an array.
     fn enter_array(&mut self) {
+        let _prev = self.array_count;
         self.array_count += 1;
+        // Each enter_array must strictly increment so nested arrays receive distinct IDs.
+        debug_assert!(
+            self.array_count > _prev,
+            "enter_array must increment array_count"
+        );
         self.array_trail.push(ArrayPos {
             array: self.array_count,
             pos: 0,


### PR DESCRIPTION
Prod-refactor half of the flatten_json mutation-coverage work (issue #41),
sized for review. Behavior-preserving — the existing flatten tests pass
unchanged.

## What
- Extract named helpers for the repeated scan checks:
  - `is_in_skipped_subtree` / `should_capture_value` for the member-state
    conditions in `read_object`
  - `at_digit` / `at_byte` for the "in-bounds and matches" checks
    `read_number` repeated per digit/sign/exponent step
  - `has_unicode_escape_at` / `peek_next_byte` for the `\uXXXX` and
    escape-pair lookahead in `read_unicode_escape` / `skip_string_value`
- Add loop-progress `debug_assert`s to the byte-scanning loops so a broken
  index increment fails fast instead of hanging (same pattern as #107).

## Follow-up
The tests that close the targeted mutation gaps land in the pt2 slice,
which branches off main after this merges.

## Test plan
- [x] `just check` (check + clippy -D warnings + fmt)
- [x] `cargo test --lib` (810 passed)