### PR TITLE
test: cover wildcard trailing-backslash + anything-but empty-value (#41)

### DIFF
--- a/src/automaton/arena.rs
+++ b/src/automaton/arena.rs
@@ -7546,6 +7546,22 @@ mod wildcard_arena_tests {
     }
 
     #[test]
+    fn test_wildcard_arena_fa_trailing_backslash() {
+        // A trailing backslash with nothing to escape is matched as a literal backslash.
+        let fm = Arc::new(FieldMatcher::with_match_id(1));
+        let (arena, start) = make_wildcard_arena_fa(b"foo\\", fm);
+
+        assert!(
+            matches_value(&arena, start, b"foo\\"),
+            "Should match 'foo\\'"
+        );
+        assert!(
+            !matches_value(&arena, start, b"foo"),
+            "Should NOT match 'foo'"
+        );
+    }
+
+    #[test]
     fn test_wildcard_arena_fa_merge() {
         let fm1 = Arc::new(FieldMatcher::with_match_id(1));
         let fm2 = Arc::new(FieldMatcher::with_match_id(2));
@@ -7666,6 +7682,17 @@ mod anything_but_arena_tests {
             matches_value(&arena, start, b"anything"),
             "Should match 'anything'"
         );
+        assert!(matches_value(&arena, start, b""), "Should match empty");
+    }
+
+    #[test]
+    fn test_anything_but_arena_fa_empty_value() {
+        // An empty excluded value is ignored, so every value still matches.
+        let fm = Arc::new(FieldMatcher::with_match_id(1));
+        let excluded = vec![b"".to_vec()];
+        let (arena, start) = make_anything_but_arena_fa(&excluded, fm);
+
+        assert!(matches_value(&arena, start, b"foo"), "Should match 'foo'");
         assert!(matches_value(&arena, start, b""), "Should match empty");
     }
 


### PR DESCRIPTION
Closes the two non-equivalent surviving mutants on the arena wildcard/anything-but builders.

- **Wildcard trailing backslash** (`parse_wildcard_segments`): no test fed a pattern ending in a lone `\`, so the bounds check at the escape branch (`i + 1 < len`) could be relaxed without notice — the relaxed form reads past the pattern. New test confirms a trailing backslash is matched as a literal backslash. (The validator rejects this input, but the builder is `pub` and handles it defensively.)
- **Anything-but empty value** (`build_anything_but_step`): no test fed an empty excluded value, so the `&& !val.is_empty()` guard could be dropped without notice — dropping it indexes an empty value. New test confirms an empty excluded value is ignored so every value still matches, matching Go upstream's `index > lastIndex` no-op.

Tests-only, +27 lines. Mutation gate over the 11 builder fns: 43 caught, 13 unviable, 7 timeouts (infinite-loop `+=` mutants), 17 missed before these tests. The two tests kill the 4 non-equivalent misses; the remaining 13 are equivalent (ordering-only choices that `with_mappings` normalizes by byte index, a no-op fill where the continuation default is always success, and an unreachable one-empty-suffix case in UTF-8 case folding).