### PR TITLE
feat!: reject unknown JSON escapes in pattern strings (#41)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,11 +24,7 @@ Style inspired by [ripgrep's CHANGELOG](https://github.com/BurntSushi/ripgrep/bl
 - `[^x]+` patterns (17K-state Unicode NFA) exceeded the DFA budget and regressed; SIMD acceleration via `AccelInfo::try_accelerate` restores performance (`regexp_negated_1k`: 3.2 µs → 652 ns)
 
 ### Breaking
-- Pattern parsing now rejects unknown JSON escapes. Previously `\X` in a
-  pattern string was silently treated as `X`; now it returns
-  `QuaminaError::InvalidPattern`. Matches the JSON spec and upstream Go
-  behavior. Patterns using only the standard escapes
-  (`\" \\ \/ \b \f \n \r \t \uXXXX`) are unaffected.
+- Pattern parsing rejects unknown JSON escapes (e.g. `\z`), matching Go upstream's `readTextWithEscapes`
 
 ## [0.5.0] — 2026-03-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,13 @@ Style inspired by [ripgrep's CHANGELOG](https://github.com/BurntSushi/ripgrep/bl
 ### Fixed
 - `[^x]+` patterns (17K-state Unicode NFA) exceeded the DFA budget and regressed; SIMD acceleration via `AccelInfo::try_accelerate` restores performance (`regexp_negated_1k`: 3.2 µs → 652 ns)
 
+### Breaking
+- Pattern parsing now rejects unknown JSON escapes. Previously `\X` in a
+  pattern string was silently treated as `X`; now it returns
+  `QuaminaError::InvalidPattern`. Matches the JSON spec and upstream Go
+  behavior. Patterns using only the standard escapes
+  (`\" \\ \/ \b \f \n \r \t \uXXXX`) are unaffected.
+
 ## [0.5.0] — 2026-03-23
 
 ### Changed

--- a/src/json.rs
+++ b/src/json.rs
@@ -940,6 +940,10 @@ impl<'a> Parser<'a> {
             if c == '\\' {
                 self.advance();
                 if let Some(escaped) = self.peek() {
+                    // Forward-progress invariant: every escape arm must advance
+                    // past the escape character, or the outer loop re-peeks `\`
+                    // forever.
+                    let _prev_pos_in_escape = self.pos;
                     match escaped {
                         'n' => {
                             result.push('\n');
@@ -999,11 +1003,19 @@ impl<'a> Parser<'a> {
                                 result.push(ch);
                             }
                         }
-                        _ => {
-                            result.push(escaped);
-                            self.advance();
+                        other => {
+                            // Per JSON spec only `" \ / b f n r t u` are valid
+                            // escapes; matching Go's readTextWithEscapes, any
+                            // other character is rejected.
+                            return Err(QuaminaError::InvalidPattern(format!(
+                                "invalid escape \\{other} in pattern string"
+                            )));
                         }
                     }
+                    debug_assert!(
+                        self.pos > _prev_pos_in_escape,
+                        "parse_string escape arm must advance past the escape char"
+                    );
                 }
             } else {
                 result.push(c);
@@ -1095,5 +1107,20 @@ impl<'a> Parser<'a> {
         } else {
             Err(QuaminaError::InvalidJson(format!("expected '{c}'")))
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_string_rejects_unknown_escape() {
+        let mut parser = Parser::new(r#""\z""#);
+        let err = parser.parse_string().unwrap_err();
+        assert!(
+            matches!(err, QuaminaError::InvalidPattern(ref msg) if msg.contains("\\z")),
+            "expected InvalidPattern containing `\\z`, got {err:?}",
+        );
     }
 }


### PR DESCRIPTION
## Summary
- `Parser::parse_string` (used by `parse_pattern`) returns `QuaminaError::InvalidPattern` on any escape other than `\" \\ \/ \b \f \n \r \t \uXXXX`. Previously the unknown-escape arm silently consumed the backslash and pushed the trailing character.
- Mirrors the value-side rejection already present in `flatten_json` (and Go upstream's `readTextWithEscapes` default → `"malformed \-escape in text"`), so patterns and event values now share the same JSON-escape contract.
- Added a `debug_assert!` documenting the scanner's termination invariant: every escape arm must advance past the escape character.
- CHANGELOG entry under "Breaking".

## Coverage
- New direct unit test on `Parser::parse_string` for `\z`.
- `cargo mutants -F parse_string` (fast nextest gate): 15 → 13 caught, 2 unviable, 0 missed.
- `just check` + `cargo test --lib` green (855 tests).

## Test plan
- [x] `just check`
- [x] `cargo test --lib`
- [x] `cargo mutants -F parse_string` (0 missed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)