### PR TITLE
refactor: drive unpack_arena_table off a slice fill (#41)

### DIFF
--- a/src/automaton/arena.rs
+++ b/src/automaton/arena.rs
@@ -2027,11 +2027,9 @@ fn merge_arena_tables(
 fn unpack_arena_table(table: &SmallTable, unpacked: &mut [StateId; BYTE_CEILING]) {
     let mut byte_idx = 0usize;
     for (i, &ceiling) in table.ceilings.iter().enumerate() {
-        let ceiling = ceiling as usize;
-        while byte_idx < ceiling && byte_idx < BYTE_CEILING {
-            unpacked[byte_idx] = table.steps[i];
-            byte_idx += 1;
-        }
+        let end = ceiling as usize;
+        unpacked[byte_idx..end].fill(table.steps[i]);
+        byte_idx = end;
     }
 }
 


### PR DESCRIPTION
The inner loop walked `byte_idx` from one ceiling to the next with `+= 1`, copying `table.steps[i]` byte-by-byte. cargo-mutants found both a timeout (`+= → *=` makes `0 *= 2 = 0`, infinite loop) and a missed `< → <=` on a `byte_idx < BYTE_CEILING` guard that was already dead — `ceilings` is `SmallVec<[u8; 8]>` whose only writers cap at `BYTE_CEILING_U8` (the sentinel push + the `i` index into the `BYTE_CEILING`-sized `unpacked` array during `pack`), so `ceiling as usize` never exceeds `BYTE_CEILING`.

Replace the inner `while` with `unpacked[byte_idx..end].fill(...)`. The `+=`, the redundant guard, and the per-byte index disappear in one rewrite. `slice.fill()` is also the idiomatic form for a constant-value fill.

Scoped gate (`-F unpack_arena_table`):

```
before  10 mutants  7 caught  1 unviable  1 timeout  1 missed
after    1 mutant   0 caught  1 unviable  0 timeouts 0 missed
```

855 lib tests green; `just check` clean.