### PR TITLE
refactor: drive parse_numeric_comparison off chunks_exact (#41)

### DIFF
--- a/src/json.rs
+++ b/src/json.rs
@@ -768,32 +768,30 @@ fn parse_numeric_comparison(arr: &[Value]) -> Option<NumericComparison> {
     let mut lower = None;
     let mut upper = None;
 
-    let mut i = 0;
-    while i < arr.len() {
-        if let Value::String(op) = &arr[i] {
-            if i + 1 >= arr.len() {
-                return None;
-            }
-            let num = match &arr[i + 1] {
-                Value::Number(n) => n.parse::<f64>().ok()?,
-                _ => return None,
-            };
-
-            match op.as_str() {
-                ">" => lower = Some((false, num)),
-                ">=" => lower = Some((true, num)),
-                "<" => upper = Some((false, num)),
-                "<=" => upper = Some((true, num)),
-                "=" => {
-                    lower = Some((true, num));
-                    upper = Some((true, num));
-                }
-                _ => return None,
-            }
-            i += 2;
-        } else {
+    let mut pairs = arr.chunks_exact(2);
+    for pair in &mut pairs {
+        let Value::String(op) = &pair[0] else {
             return None;
+        };
+        let num = match &pair[1] {
+            Value::Number(n) => n.parse::<f64>().ok()?,
+            _ => return None,
+        };
+
+        match op.as_str() {
+            ">" => lower = Some((false, num)),
+            ">=" => lower = Some((true, num)),
+            "<" => upper = Some((false, num)),
+            "<=" => upper = Some((true, num)),
+            "=" => {
+                lower = Some((true, num));
+                upper = Some((true, num));
+            }
+            _ => return None,
         }
+    }
+    if !pairs.remainder().is_empty() {
+        return None;
     }
 
     Some(NumericComparison { lower, upper })

--- a/src/tests_core.rs
+++ b/src/tests_core.rs
@@ -2953,8 +2953,7 @@ fn test_transform_lookaround_alternation_rejected() {
 
 #[test]
 fn test_numeric_comparison_missing_value_after_operator() {
-    // Array with only an operator and no following value — should error.
-    // Catches mutation: replace + with * in parse_numeric_comparison (i+1 vs i*1 at i=0)
+    // Odd-length numeric arrays — operator without a paired value — must error.
     let mut q = Quamina::<&str>::new();
     let result = q.add_pattern("bad", r#"{"x": [{"numeric": [">"]}]}"#);
     assert!(result.is_err(), "Single-element numeric array should fail");


### PR DESCRIPTION
## Summary

T4 of round-2 mutation-coverage tracking. The `parse_numeric_comparison` op/value pair loop drove a manual `let mut i = 0; while i < arr.len(); i += 2` with a `i + 1 >= arr.len()` bounds check. cargo-mutants flagged the `i += 2` site (line 793) as a timeout (`+= → *=` → `i *= 2` stalls at zero).

Replace the counter loop with `arr.chunks_exact(2)` and treat any trailing element via `pairs.remainder().is_empty()`. The pair shape matches the input semantics (operator + number) without an explicit counter or hand-rolled bounds check.

## Scoped gate

`cargo mutants --config /tmp/mutants-nextest.toml --file src/json.rs -F 'parse_numeric_comparison'`: 9 mutants — 6 caught + 3 unviable, **0 missed, 0 timeouts**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)