### PR TITLE
refactor: assemble ipv6 group value with from_be_bytes (#41)

### DIFF
--- a/src/automaton/arena.rs
+++ b/src/automaton/arena.rs
@@ -3912,7 +3912,7 @@ fn make_ipv6_cidr_arena_fa(
         let group_start_bit = group_idx * 16;
         let group_end_bit = group_start_bit + 16;
 
-        let group_value = (u16::from(network[byte_idx]) << 8) | u16::from(network[byte_idx + 1]);
+        let group_value = u16::from_be_bytes([network[byte_idx], network[byte_idx + 1]]);
 
         let (min_val, max_val) = if prefix_len as usize >= group_end_bit {
             (group_value, group_value)


### PR DESCRIPTION
The IPv6 CIDR builder read each 16-bit group from its two network bytes with a hand-rolled `(hi << 8) | lo`. `u16::from_be_bytes([hi, lo])` says the same thing in the standard library's own words for "big-endian u16 from two bytes," and it carries no `<<`/`|` operators 

