### PR TITLE
refactor: drop redundant ipv6 :: split-length guard (#41)

### DIFF
--- a/src/json.rs
+++ b/src/json.rs
@@ -134,10 +134,10 @@ impl CidrPattern {
             } else {
                 parts[0].split(':').collect()
             };
-            let right: Vec<&str> = if parts.len() > 1 && !parts[1].is_empty() {
-                parts[1].split(':').collect()
-            } else {
+            let right: Vec<&str> = if parts[1].is_empty() {
                 vec![]
+            } else {
+                parts[1].split(':').collect()
             };
 
             if left.len() + right.len() > 8 {


### PR DESCRIPTION
When an IPv6 string contains `::`, splitting on it always yields at least two parts, and the `> 2` check just above this line rejects more than one `::`; so `parts.len()` is exactly two by the time we read the right-hand group. The extra `parts.len() > 1` guard was always true. This drops it and indexes `parts[1]` directly, leaving the right branch mirroring the left.

