### PR TITLE
test: pin nfa accel single-state gate and dedup generation counter (#41)

### DIFF
--- a/src/automaton/arena.rs
+++ b/src/automaton/arena.rs
@@ -4532,6 +4532,108 @@ mod tests {
         );
     }
 
+    // Acceleration skips input off a single state's exit set, so it is sound only
+    // while exactly one state is active; with more, it would advance past bytes the
+    // other states still need. The accel fast path must stay gated on a single
+    // active state.
+    #[test]
+    fn test_arena_nfa_skips_acceleration_with_multiple_active_states() {
+        let mut arena = StateArena::new();
+        let field_matcher = Arc::new(FieldMatcher::new());
+
+        // Literal path "abz": ...->lit_mid -b-> lit_ready -z-> lit_final -TERM-> match.
+        let match_state = arena.alloc();
+        arena[match_state].field_transitions.push(field_matcher);
+        let lit_final = arena.alloc_with_table(SmallTable::with_mappings(
+            StateId::NONE,
+            &[ARENA_VALUE_TERMINATOR],
+            &[match_state],
+        ));
+        let lit_ready =
+            arena.alloc_with_table(SmallTable::with_mappings(StateId::NONE, b"z", &[lit_final]));
+        let lit_mid =
+            arena.alloc_with_table(SmallTable::with_mappings(StateId::NONE, b"b", &[lit_ready]));
+
+        // Accelerating self-loop on every byte except its exit byte 'z'.
+        let accel_state = arena.alloc();
+        let mut unpacked = [StateId::NONE; BYTE_CEILING];
+        for (byte, slot) in unpacked.iter_mut().enumerate() {
+            if byte != b'z' as usize && byte != ARENA_VALUE_TERMINATOR as usize {
+                *slot = accel_state;
+            }
+        }
+        arena[accel_state].table.pack(&unpacked);
+        arena[accel_state].table.accel = Some(AccelInfo {
+            exit_bytes: [b'z', 0, 0],
+            len: 1,
+        });
+
+        // Start steps 'a' into the accel state directly and, via an epsilon
+        // sibling, into the literal path — so both are active from byte 1, with
+        // the accel state first in the active set.
+        let lit_entry =
+            arena.alloc_with_table(SmallTable::with_mappings(StateId::NONE, b"a", &[lit_mid]));
+        let start = arena.alloc_with_table(SmallTable::with_mappings(
+            StateId::NONE,
+            b"a",
+            &[accel_state],
+        ));
+        arena[start].table.epsilons = smallvec![lit_entry];
+
+        arena.precompute_epsilon_closures();
+
+        let mut bufs = NfaBuffers::with_capacity();
+        traverse_arena_nfa(&arena, start, b"abz", &mut bufs);
+        assert_eq!(
+            bufs.transitions.len(),
+            1,
+            "literal 'abz' must match: acceleration must not fire while a second state is active"
+        );
+    }
+
+    // The dedup pass marks states with a per-step generation so a logical clear is
+    // just a counter bump. The generation must advance each step, or states marked
+    // in one step read as duplicates in the next and get dropped.
+    #[test]
+    fn test_arena_nfa_dedup_generation_advances_between_steps() {
+        // More hubs than the dedup threshold so each 'a' step triggers a dedup.
+        const HUBS: usize = 70;
+
+        let mut arena = StateArena::new();
+        let field_matcher = Arc::new(FieldMatcher::new());
+
+        let match_state = arena.alloc();
+        arena[match_state].field_transitions.push(field_matcher);
+
+        let hubs: Vec<StateId> = (0..HUBS).map(|_| arena.alloc()).collect();
+        for (k, &hub) in hubs.iter().enumerate() {
+            if k == 0 {
+                // Hub 0 also exits to the match on the value terminator.
+                arena[hub].table = SmallTable::with_mappings(
+                    StateId::NONE,
+                    &[b'a', ARENA_VALUE_TERMINATOR],
+                    &[hub, match_state],
+                );
+            } else {
+                arena[hub].table = SmallTable::with_mappings(StateId::NONE, b"a", &[hub]);
+            }
+        }
+
+        // Start fans out to every hub via epsilon; none of its own bytes step.
+        let start = arena.alloc();
+        arena[start].table.epsilons = SmallVec::from_vec(hubs);
+
+        arena.precompute_epsilon_closures();
+
+        let mut bufs = NfaBuffers::with_capacity();
+        traverse_arena_nfa(&arena, start, b"aa", &mut bufs);
+        assert_eq!(
+            bufs.transitions.len(),
+            1,
+            "match must survive two consecutive dedup steps over a repeating active set"
+        );
+    }
+
     #[test]
     fn test_try_accelerate_arena() {
         // Test the try_accelerate_arena function directly


### PR DESCRIPTION
R1 of the round-3 close-out — the seven accel/dedup mutants that round 1 left missed in the NFA/DFA traversal loops. The audit split them by whether the guard is correctness-bearing; this PR kills the two that are, with white-box tests, and hands the five true perf toggles to R4 for suppression.

- **Single-state acceleration gate** (`traverse_arena_nfa`) is a correctness guard, not a perf toggle: memchr skips bytes off the *first* active state's exit set, so it must not fire while a second state is active or the others get stranded mid-input. The test builds an arena where, after byte 1, an accelerating self-loop runs beside a literal whose match needs the bytes acceleration would skip — the literal must still match.
- **Dedup generation counter** (`traverse_arena_nfa`) must advance on every dedup, or states stamped in an earlier step look like duplicates in a later one and get dropped. The test drives two consecutive over-threshold steps over a repeating active set; a stalled counter loses the terminating match.

Tests-only, no production change. The remaining five (the lazy-DFA self-loop *compute* trigger and the dedup `> 64` threshold) are genuine match-equivalent perf toggles: `try_compute_accel` self-validates so the trigger only changes when valid accel is computed, and dedup is correctness-neutral so its threshold can only "catch" via timeout. Always-dedup was tried and rejected — it regresses `shellstyle_multi_match` ~4.4% (5.42→5.66 µs).

Scoped gate (`traverse_lazy_dfa | traverse_arena_nfa`): 38 mutants, 7 missed → **5 missed** (28 caught, 3 unviable, 2 timeouts). The 5 are the perf toggles bound for R4; the 2 timeouts are R2's slow-path `+=`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)