### PR TITLE
test: suppress unkillable mutation-gate equivalents (#41)

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -17,8 +17,25 @@ exclude_globs = [
 # Skip doctests (they test documentation, not correctness)
 additional_cargo_test_args = ["--all-targets"]
 
-# Skip kani proof harnesses — formal verification, not production code
-exclude_re = ["kani_arena_proofs::"]
+# Skip kani proof harnesses — formal verification, not production code.
+#
+# The rest are equivalents we can't kill: the mutated operator gives the same
+# result as the original for every input, so no test can tell them apart. Each
+# has an intent comment at its source site.
+exclude_re = [
+  "kani_arena_proofs::",
+  # WTF-8 tag byte: the tag and payload never share a bit, so `|` and `^`
+  # build the same byte.
+  'replace \| with \^ in .*read_unicode_escape',
+  # Self-loop acceleration is a pure speed-up; toggling when it fires never
+  # changes a match.
+  'replace == with != in traverse_lazy_dfa',
+  # Column-anchored (not line) so it survives edits in the fn; a separate,
+  # caught `&&` at another column stays tested.
+  ':28: replace && with \|\| in traverse_lazy_dfa',
+  # Dedup drops only exact duplicates, so the `> 64` threshold is speed-only.
+  'replace > with .* in traverse_arena_nfa',
+]
 
 # Don't mutate logging/debug/panic macros — not worth testing
 skip_calls = [

--- a/src/automaton/arena.rs
+++ b/src/automaton/arena.rs
@@ -1274,7 +1274,10 @@ pub(crate) fn traverse_lazy_dfa(lazy_dfa: &mut LazyDfa, val: &[u8], transitions:
             return;
         }
 
-        // Detect self-loop and try to compute acceleration for future bytes
+        // On a self-loop, try to compute acceleration for future bytes. This is
+        // a pure speed-up: `try_compute_accel` only installs an accelerator it
+        // has re-checked, so attempting it more or less often never changes a
+        // match.
         if next == current && lazy_dfa.states[current.index()].accel.is_none() {
             lazy_dfa.try_compute_accel(current, &mut scratch);
         }
@@ -1471,8 +1474,9 @@ pub fn traverse_arena_nfa(arena: &StateArena, start: StateId, val: &[u8], bufs: 
         }
 
         // Nested quantifiers like (([abc]?)*)+ create epsilon loops that
-        // cause duplicate states to compound exponentially across steps.
-        // Dedup in-place using a generation counter when growth is detected.
+        // compound duplicate states across steps. Compact in place when growth
+        // is detected; this only drops exact duplicates, so the threshold is a
+        // speed knob, not a correctness one.
         if next_states.len() > 64 {
             *step_gen += 1;
             let generation = *step_gen;

--- a/src/flatten_json.rs
+++ b/src/flatten_json.rs
@@ -910,11 +910,11 @@ impl<'a> FlattenContext<'a, '_> {
             let mut buf = [0u8; 4];
             out.extend_from_slice(c.encode_utf8(&mut buf).as_bytes());
         } else {
-            // `read_hex_4` only returns 0..=0xFFFF, and we've already taken
-            // the high-surrogate path above, so the only thing that can
-            // make `char::from_u32` give up is a lone low surrogate. Emit
-            // it as 3-byte WTF-8 by hand. Each masked piece is statically
-            // bounded so the `try_from`s never actually fail.
+            // `read_hex_4` caps at 0xFFFF and the high-surrogate path is taken
+            // above, so the only value left for `char::from_u32` to reject is a
+            // lone low surrogate; hand-encode it as 3-byte WTF-8. The tag and
+            // the masked payload never share a bit, so OR just lays them
+            // side by side (the `try_from`s can't fail).
             debug_assert!(
                 (0xDC00..=0xDFFF).contains(&code),
                 "char::from_u32 only fails for surrogates within u16 range"
@@ -1174,6 +1174,20 @@ mod tests {
         assert_eq!(peek_next_byte(b"a", 0), None);
         assert_eq!(peek_next_byte(b"", 0), None);
         assert_eq!(peek_next_byte(b"ab", 1), None);
+    }
+
+    #[test]
+    fn test_lone_low_surrogate_wtf8_encoding() {
+        // A lone low surrogate \uDC00 has no scalar value, so it takes the
+        // hand-rolled 3-byte WTF-8 path and encodes as ED B0 80 (the value bytes
+        // include the surrounding quotes). Pins the masks and shifts on that
+        // path: any change to them moves the output and fails here.
+        let tree = make_tree(&["k"]);
+        let mut state = State::new();
+        let event = b"{\"k\": \"\\uDC00\"}";
+        let fields = state.flatten(event, &tree).unwrap();
+        assert_eq!(fields.len(), 1);
+        assert_eq!(fields[0].val.as_bytes(), &[0x22, 0xED, 0xB0, 0x80, 0x22]);
     }
 
     #[test]


### PR DESCRIPTION
These eight mutants change *how* the code reaches its answer, never the answer itself — so no test can ever catch them, and they'd keep the mutation gate red forever. This suppresses them in `.cargo/mutants.toml`, with a plain-English intent comment at each source site.

- **WTF-8 tag bytes** in `read_unicode_escape`: a byte is built by combining a fixed tag with a small payload. OR and XOR only disagree when the two share a switched-on bit — and here the tag and the (masked) payload live in different parts of the byte and never overlap. So `|` and `^` produce the identical byte for every input.
- **Self-loop acceleration trigger**: this only decides *when* to attempt a speed-up. The speed-up double-checks itself and refuses to do anything unsafe, so attempting it more or less often only changes speed, never a match.
- **Dedup threshold**: this only decides *when* to discard duplicate work. Duplicates are duplicates, so the final result is identical either way — only speed moves.

The `&&` exclude is anchored on its column, not its line, so it survives edits elsewhere in the function — and a separate, *caught* `&&` in the same function stays tested.

Also adds `test_lone_low_surrogate_wtf8_encoding`: that path had no test pinning its output, so the suppressed OR sat bare. The test drives `\uDC00` through the flattener and asserts `ED B0 80`, catching every *killable* change to the masks/shifts/ORs at that site (verified: `|→&` flips the lead byte and fails it). The suppressed `|→^` stays suppressed because it provably can't change the output.

Scoped gate over the traversal fns + `read_unicode_escape`: 44 mutants → 38 caught + 6 unviable, **0 missed, 0 timeouts**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)