### PR TITLE
ci: gate PRs on incremental mutation testing (#41)

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -5,6 +5,11 @@
 # Use a fast profile with no debug symbols
 profile = "mutants"
 
+# nextest runs each test in its own process, so a mutant is scored the moment a
+# test fails. The per-mutant timeout then means "this mutant hung", not "the test
+# binary is slow". (Gate-only: the repo's own `cargo test` skips no doctests.)
+test_tool = "nextest"
+
 # Only mutate real source code, not generated tables or test fixtures
 exclude_globs = [
   "src/case_folding.rs",       # auto-generated Unicode tables
@@ -14,8 +19,15 @@ exclude_globs = [
   "src/kani_proofs.rs",        # formal verification, not runtime code
 ]
 
-# Skip doctests (they test documentation, not correctness)
-additional_cargo_test_args = ["--all-targets"]
+# Library unit tests only. Do NOT add `--all-targets`: it builds the Criterion
+# benches unoptimized, which overruns the per-mutant timeout and fails the
+# baseline. The two excluded tests are slow (concurrent-stress and regexp
+# fuzzing) and catch nothing the rest of the suite doesn't.
+additional_cargo_test_args = [
+  "--lib",
+  "-E",
+  "not (test(test_concurrent_update_during_matching) | test(test_regexp_validity))",
+]
 
 # Skip kani proof harnesses — formal verification, not production code.
 #

--- a/.github/workflows/mutants.yml
+++ b/.github/workflows/mutants.yml
@@ -1,10 +1,64 @@
 name: mutation-testing
 
 on:
+  pull_request:
+    branches: [main]
   workflow_dispatch:
 
 jobs:
-  mutants:
+  # Mutates only the lines a PR changed, so it finishes in seconds and fails when
+  # a changed line of production code has no test covering it. No Rust changes =>
+  # no mutants => pass.
+  incremental:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0 # need the base branch to diff against
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-mutants,cargo-nextest
+
+      - name: Diff against base branch
+        run: git diff "origin/${{ github.base_ref }}...HEAD" > pr.diff
+
+      - name: Mutation-test changed code
+        run: cargo mutants --no-shuffle -vV --in-diff pr.diff
+
+      - name: Summary
+        if: always()
+        run: |
+          echo "## Mutation results (changed lines)" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          for f in caught missed timeout unviable; do
+            count=$(wc -l < "mutants.out/${f}.txt" 2>/dev/null || echo 0)
+            echo "- **${f}**: ${count}" >> "$GITHUB_STEP_SUMMARY"
+          done
+          if [ -s mutants.out/missed.txt ]; then
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "### Missed mutants" >> "$GITHUB_STEP_SUMMARY"
+            echo '```' >> "$GITHUB_STEP_SUMMARY"
+            cat mutants.out/missed.txt >> "$GITHUB_STEP_SUMMARY"
+            echo '```' >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload results
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: mutants-incremental
+          path: mutants.out/
+          retention-days: 30
+
+  # Whole-tree sweep, sharded. Too slow for a per-PR gate; run on demand as the
+  # authoritative 0-missed / 0-timeout check.
+  full:
+    if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 120
     strategy:
@@ -18,7 +72,7 @@ jobs:
 
       - uses: taiki-e/install-action@v2
         with:
-          tool: cargo-mutants
+          tool: cargo-mutants,cargo-nextest
 
       - name: Run mutation testing (shard ${{ matrix.shard }}/8)
         run: cargo mutants --no-shuffle -vV --timeout 120 -j 2 --shard ${{ matrix.shard }}/8 --sharding round-robin

--- a/justfile
+++ b/justfile
@@ -136,6 +136,11 @@ mutants-diff *args:
     git diff origin/main.. > /tmp/quamina-mutants.diff
     cargo mutants -vV --in-diff /tmp/quamina-mutants.diff --in-place {{args}}
 
+# Mutation gate for one file (or `regex` for part of it): 0 missed, 0 timeout
+[group('validate')]
+mutants-verify file regex='':
+    ./scripts/mutants-verify.sh {{file}} {{regex}}
+
 # Start LLM Agent in this repo (currently claude-code with dangerously-skip-permissions)
 [group('agent')]
 ai:

--- a/scripts/mutants-verify.sh
+++ b/scripts/mutants-verify.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# Execution-grounded mutation gate for one file (or part of one file).
+#
+#   ./scripts/mutants-verify.sh <src/path.rs> [mutant-name-regex]
+#
+# Examples:
+#   ./scripts/mutants-verify.sh src/regexp/parser.rs
+#   ./scripts/mutants-verify.sh src/regexp/parser.rs 'read_atom|read_group'
+#
+# Passes (exit 0) only when the lib tests are green AND the scoped file has
+# zero MISSED and zero TIMEOUT mutants. A timeout is treated as bad as a
+# missed mutant: this is a high-performance library, and a loop mutation that
+# hangs or runs pathologically is a real hole, not a free pass.
+#
+# Isolated by design: results go to target/mutants-verify/ and never touch
+# mutants.out/ or any mutants.out.backup.* directory. Trustworthy by design:
+# a watchdog kill is reported as INCOMPLETE, never as a false PASS.
+#
+# Requires: cargo-mutants, cargo-nextest. macOS for the memory watchdog
+# (no-op elsewhere). Honors .cargo/mutants.toml.
+#
+# Env overrides:
+#   MUTANTS_TIMEOUT   per-mutant test timeout, seconds (default 10)
+#   MUTANTS_JOBS      parallel jobs (default 4)
+#   SKIP_BASELINE     set to 1 to skip the up-front `cargo test --lib`
+#
+# Exit codes: 0 = PASS, 1 = FAIL (gaps or incomplete), 2 = usage/setup error.
+
+set -euo pipefail
+
+REPO_ROOT="$(git -C "$(dirname "$0")" rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+FILE="${1:-}"
+REGEX="${2:-}"
+if [[ -z "$FILE" ]]; then
+    echo "usage: $0 <src/path.rs> [mutant-name-regex]" >&2
+    exit 2
+fi
+if [[ ! -f "$FILE" ]]; then
+    echo "error: no such file: $FILE" >&2
+    exit 2
+fi
+
+TIMEOUT="${MUTANTS_TIMEOUT:-10}"
+JOBS="${MUTANTS_JOBS:-4}"
+OUTDIR="$REPO_ROOT/target/mutants-verify"
+OOM_FLAG="$OUTDIR/.oom-killed"
+
+# Clean only our own isolated dir so the scoped run's txt files are authoritative.
+rm -rf "$OUTDIR"
+mkdir -p "$OUTDIR"
+
+# --- up-front green-tree check (--baseline skip trusts the caller) ----------
+if [[ "${SKIP_BASELINE:-0}" != "1" ]]; then
+    echo "==> baseline: cargo test --lib"
+    if ! cargo test --lib --quiet; then
+        echo "FAIL: baseline lib tests are red — fix tests before the mutation gate" >&2
+        exit 1
+    fi
+fi
+
+# --- memory-pressure watchdog (macOS only) ---------------------------------
+# Mirrors the failsafe from issue #41: kill the run before the OS reboots the
+# laptop, and leave a sentinel so a kill is never mistaken for a clean PASS.
+WATCHDOG_PID=""
+start_watchdog() {
+    [[ "$(uname -s)" == "Darwin" ]] || return 0
+    (
+        while pgrep -qf cargo-mutants; do
+            lvl=$(sysctl -n kern.memorystatus_vm_pressure_level 2>/dev/null || echo 0)
+            free=$(memory_pressure 2>/dev/null \
+                | awk -F': ' '/free percentage/{gsub(/%/,"",$2);print $2}')
+            if [[ "$lvl" -ge 4 ]] || { [[ -n "$free" ]] && [[ "$free" -lt 6 ]]; }; then
+                echo "$(date): pressure=$lvl free=${free}% — killing cargo-mutants" >&2
+                : > "$OOM_FLAG"
+                pkill -9 -f cargo-mutants
+                break
+            fi
+            sleep 15
+        done
+    ) &
+    WATCHDOG_PID=$!
+}
+stop_watchdog() {
+    [[ -n "$WATCHDOG_PID" ]] && kill "$WATCHDOG_PID" 2>/dev/null || true
+}
+trap stop_watchdog EXIT
+start_watchdog
+
+# --- scoped mutation run ---------------------------------------------------
+CAFFEINATE=()
+command -v caffeinate >/dev/null 2>&1 && CAFFEINATE=(caffeinate -i)
+
+ARGS=(mutants -vV --baseline skip -j "$JOBS" --timeout "$TIMEOUT"
+      --test-tool nextest --file "$FILE" --output "$OUTDIR")
+[[ -n "$REGEX" ]] && ARGS+=(--re "$REGEX")
+
+echo "==> cargo ${ARGS[*]}"
+MUT_RC=0
+"${CAFFEINATE[@]}" cargo "${ARGS[@]}" || MUT_RC=$?
+
+stop_watchdog
+trap - EXIT
+
+# --- adjudicate ------------------------------------------------------------
+if [[ -f "$OOM_FLAG" ]]; then
+    echo "INCOMPLETE: run was killed under memory pressure — result is NOT trustworthy" >&2
+    echo "RESULT: FAIL ($FILE) — incomplete (memory pressure)"
+    exit 1
+fi
+
+RESULTS="$OUTDIR/mutants.out"
+count() { [[ -s "$RESULTS/$1" ]] && grep -c . "$RESULTS/$1" || echo 0; }
+
+if [[ ! -d "$RESULTS" ]]; then
+    echo "INCOMPLETE: no results at $RESULTS (cargo-mutants rc=$MUT_RC)" >&2
+    echo "RESULT: FAIL ($FILE) — no results"
+    exit 1
+fi
+
+MISSED=$(count missed.txt)
+TIMEOUT_N=$(count timeout.txt)
+CAUGHT=$(count caught.txt)
+UNVIABLE=$(count unviable.txt)
+SCOPE="$FILE${REGEX:+ /$REGEX/}"
+
+echo
+echo "RESULT: $SCOPE — caught $CAUGHT, unviable $UNVIABLE, missed $MISSED, timeout $TIMEOUT_N"
+if [[ "$MISSED" -ne 0 ]]; then
+    echo "--- missed ---"; cat "$RESULTS/missed.txt"
+fi
+if [[ "$TIMEOUT_N" -ne 0 ]]; then
+    echo "--- timeout (counts as missed for this gate) ---"; cat "$RESULTS/timeout.txt"
+fi
+
+if [[ "$MISSED" -eq 0 && "$TIMEOUT_N" -eq 0 ]]; then
+    echo "GATE PASS: $SCOPE — missed 0, timeout 0"
+    exit 0
+fi
+echo "GATE FAIL: $SCOPE — $MISSED missed, $TIMEOUT_N timeout" >&2
+exit 1


### PR DESCRIPTION
The mutation-coverage work for #41 is finished, but two loose ends were left: the gate never ran on PRs, and the fast config the work was checked against only lived in a `/tmp` file, never committed. This wires up both.

`.cargo/mutants.toml` becomes that fast config. It runs the library unit tests under nextest and drops `--all-targets`, which had been pulling the benchmarks into every mutant build and timing out the baseline — the gotcha that's bitten every local run. The two slowest tests are excluded; neither catches anything the rest of the suite misses. The per-mutant suite goes from ~30s to ~3s.

`mutants.yml` gets a job that runs on every PR and only mutates the lines that PR changed, so it finishes in seconds and fails when a changed line of production code has no test covering it. The slow whole-tree sweep stays as an on-demand job.

`just mutants-verify <file>` runs the same gate locally.

nextest is only used for mutation testing — the normal `cargo test` and CI are unchanged, since nextest would skip this repo's 27 doctests.

Checked locally: a scoped run is 0 missed / 0 timeout, a docs-only diff passes with no mutants, and a one-line code change gets mutated on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)