### PR TITLE
tooling: add `just mutants-local` for the full-tree mutation sweep (#41)

### DIFF
--- a/justfile
+++ b/justfile
@@ -141,6 +141,34 @@ mutants-diff *args:
 mutants-verify file regex='':
     ./scripts/mutants-verify.sh {{file}} {{regex}}
 
+# caffeinate keeps the laptop awake; the watchdog kills cargo-mutants before the
+# OS reboots, and a pressure kill reports INCOMPLETE, never a pass. nextest +
+# lib-only come from .cargo/mutants.toml; scope with args like `--file src/...`.
+# Full-tree local mutation sweep with the macOS memory-pressure watchdog
+[group('validate')]
+mutants-local *args:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    cd "{{justfile_directory()}}"
+    OOM_FLAG="$(pwd)/target/mutants-local.oom"
+    export OOM_FLAG
+    rm -f "$OOM_FLAG"
+    source scripts/mutants-watchdog.sh
+    caffeinate=()
+    command -v caffeinate >/dev/null 2>&1 && caffeinate=(caffeinate -i)
+    start_watchdog
+    trap stop_watchdog EXIT
+    rc=0
+    "${caffeinate[@]}" cargo mutants -vV --iterate --baseline skip \
+        -j 4 --timeout 10 {{args}} || rc=$?
+    stop_watchdog
+    trap - EXIT
+    if [[ -f "$OOM_FLAG" ]]; then
+        echo "INCOMPLETE: run killed under memory pressure — result is NOT trustworthy" >&2
+        exit 1
+    fi
+    exit "$rc"
+
 # Start LLM Agent in this repo (currently claude-code with dangerously-skip-permissions)
 [group('agent')]
 ai:

--- a/scripts/mutants-verify.sh
+++ b/scripts/mutants-verify.sh
@@ -61,30 +61,9 @@ if [[ "${SKIP_BASELINE:-0}" != "1" ]]; then
 fi
 
 # --- memory-pressure watchdog (macOS only) ---------------------------------
-# Mirrors the failsafe from issue #41: kill the run before the OS reboots the
-# laptop, and leave a sentinel so a kill is never mistaken for a clean PASS.
-WATCHDOG_PID=""
-start_watchdog() {
-    [[ "$(uname -s)" == "Darwin" ]] || return 0
-    (
-        while pgrep -qf cargo-mutants; do
-            lvl=$(sysctl -n kern.memorystatus_vm_pressure_level 2>/dev/null || echo 0)
-            free=$(memory_pressure 2>/dev/null \
-                | awk -F': ' '/free percentage/{gsub(/%/,"",$2);print $2}')
-            if [[ "$lvl" -ge 4 ]] || { [[ -n "$free" ]] && [[ "$free" -lt 6 ]]; }; then
-                echo "$(date): pressure=$lvl free=${free}% — killing cargo-mutants" >&2
-                : > "$OOM_FLAG"
-                pkill -9 -f cargo-mutants
-                break
-            fi
-            sleep 15
-        done
-    ) &
-    WATCHDOG_PID=$!
-}
-stop_watchdog() {
-    [[ -n "$WATCHDOG_PID" ]] && kill "$WATCHDOG_PID" 2>/dev/null || true
-}
+# Shared with `just mutants-local`; OOM_FLAG (set above) is the kill sentinel,
+# adjudicated below so a pressure kill reports INCOMPLETE, never a clean PASS.
+source "$REPO_ROOT/scripts/mutants-watchdog.sh"
 trap stop_watchdog EXIT
 start_watchdog
 

--- a/scripts/mutants-watchdog.sh
+++ b/scripts/mutants-watchdog.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Shared memory-pressure watchdog for the local cargo-mutants runs (issue #41).
+#
+# A full-tree mutation sweep builds hundreds of mutated trees in parallel; on a
+# memory-constrained laptop that can exhaust RAM and force a reboot. This kills
+# cargo-mutants first, and records the kill so a run the OS cut short is never
+# reported as a clean PASS.
+#
+# Source it, point OOM_FLAG at a sentinel path, then bracket the run:
+#
+#   OOM_FLAG=/path/to/.oom-killed
+#   source scripts/mutants-watchdog.sh
+#   start_watchdog
+#   trap stop_watchdog EXIT
+#   cargo mutants ...
+#   stop_watchdog
+#   [[ -f "$OOM_FLAG" ]] && { echo INCOMPLETE; exit 1; }
+#
+# macOS only: it reads the kernel memory-pressure level and free-memory
+# percentage and SIGKILLs cargo-mutants once either crosses the danger line.
+# Linux has neither sysctl key nor memory_pressure(1), so start_watchdog is a
+# no-op there and the run proceeds without a killer (CI/Linux is unaffected).
+
+WATCHDOG_PID=""
+
+start_watchdog() {
+    [[ "$(uname -s)" == "Darwin" ]] || return 0
+    (
+        while pgrep -qf cargo-mutants; do
+            lvl=$(sysctl -n kern.memorystatus_vm_pressure_level 2>/dev/null || echo 0)
+            free=$(memory_pressure 2>/dev/null \
+                | awk -F': ' '/free percentage/{gsub(/%/,"",$2);print $2}')
+            if [[ "$lvl" -ge 4 ]] || { [[ -n "$free" ]] && [[ "$free" -lt 6 ]]; }; then
+                echo "$(date): pressure=$lvl free=${free}% — killing cargo-mutants" >&2
+                : > "$OOM_FLAG"
+                pkill -9 -f cargo-mutants
+                break
+            fi
+            sleep 15
+        done
+    ) &
+    WATCHDOG_PID=$!
+}
+
+stop_watchdog() {
+    [[ -n "$WATCHDOG_PID" ]] && kill "$WATCHDOG_PID" 2>/dev/null || true
+}


### PR DESCRIPTION
The local deep run was a hand-typed two-terminal ritual — `caffeinate -i cargo mutants --iterate --baseline skip -j 4 --timeout 10 --test-tool nextest` in one window, the memory-pressure killer loop in another. This makes it one command.

The watchdog #147 put in `scripts/mutants-verify.sh` is lifted into a shared `scripts/mutants-watchdog.sh` that both the verify script and the new `just mutants-local *args` recipe source — one killer loop to maintain. A kill under memory pressure reports INCOMPLETE and exits non-zero, never a clean pass.

`--test-tool nextest` is not re-passed — it, `--lib`, and the two-test exclusion live in `.cargo/mutants.toml`. The recipe carries only the run-mode flags the config cannot, plus passthrough `*args` for scoping (`--file ...`). The watchdog no-ops on Linux, so the recipe still runs on CI without a killer. The other `mutants*` recipes are untouched.

Validated: a clean `just mutants-local --file src/automaton/small_table.rs` reports 4 caught, 9 unviable, 0 missed, 0 timeout, exit 0; the watchdog starts and self-reaps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)