### PR TITLE
fix: bound {n,m} regexp quantifier counts at parse time

### DIFF
--- a/src/regexp/nfa.rs
+++ b/src/regexp/nfa.rs
@@ -214,10 +214,13 @@ fn make_one_arena_branch_fa(
             let n = usize::try_from(qa.quant_min).expect("quant_min must be non-negative");
             let m = usize::try_from(qa.quant_max).expect("quant_max must be non-negative");
 
-            // Sanity invariant: + and * use the plus_star path above.
+            // This expansion allocates one state per repetition, so it relies
+            // on the parser bounding both counts. Note that quant_max ==
+            // REGEXP_QUANTIFIER_MAX does NOT imply + or *: `{n,}` and
+            // `{n,100}` land here whenever n > 1.
             debug_assert!(
-                qa.quant_max != REGEXP_QUANTIFIER_MAX,
-                "+/* must take the plus_star path, not the general {{n,m}} expansion"
+                qa.quant_max <= REGEXP_QUANTIFIER_MAX,
+                "parser must bound quantifier repetition counts"
             );
 
             // First, build the optional part (m-n copies, each with epsilon skip)

--- a/src/regexp/nfa.rs
+++ b/src/regexp/nfa.rs
@@ -214,10 +214,9 @@ fn make_one_arena_branch_fa(
             let n = usize::try_from(qa.quant_min).expect("quant_min must be non-negative");
             let m = usize::try_from(qa.quant_max).expect("quant_max must be non-negative");
 
-            // This expansion allocates one state per repetition, so it relies
-            // on the parser bounding both counts. Note that quant_max ==
-            // REGEXP_QUANTIFIER_MAX does NOT imply + or *: `{n,}` and
-            // `{n,100}` land here whenever n > 1.
+            // One state is allocated per repetition, so this expansion relies
+            // on the parser capping both counts. `{n,}` and `{n,100}` reach
+            // this path with quant_max equal to the +/* sentinel when n > 1.
             debug_assert!(
                 qa.quant_max <= REGEXP_QUANTIFIER_MAX,
                 "parser must bound quantifier repetition counts"

--- a/src/regexp/parser.rs
+++ b/src/regexp/parser.rs
@@ -1913,6 +1913,15 @@ fn read_quantifier(parse: &mut RegexpParse, qa: &mut QuantifiedAtom) -> Result<(
     Ok(())
 }
 
+fn quantifier_too_large_error(parse: &RegexpParse) -> Error {
+    Error {
+        message: format!(
+            "invalid range quantifier, repetition count exceeds maximum of {REGEXP_QUANTIFIER_MAX}"
+        ),
+        offset: parse.last_index,
+    }
+}
+
 /// Read a range quantifier {m,n}
 fn read_range_quantifier(parse: &mut RegexpParse, qa: &mut QuantifiedAtom) -> Result<(), Error> {
     // Helper to convert EOF to a more specific error
@@ -1947,6 +1956,13 @@ fn read_range_quantifier(parse: &mut RegexpParse, qa: &mut QuantifiedAtom) -> Re
                 message: "invalid number in quantifier".into(),
                 offset: parse.last_index,
             })?;
+            // The NFA builder materializes one state per repetition, so an
+            // unbounded count would let a single pattern allocate an
+            // arbitrarily large automaton. Reject oversized counts here,
+            // before any states are built.
+            if lo > REGEXP_QUANTIFIER_MAX {
+                return Err(quantifier_too_large_error(parse));
+            }
             qa.quant_min = lo;
             // Default to exact match; will be updated if comma is present
             qa.quant_max = lo;
@@ -1993,6 +2009,9 @@ fn read_range_quantifier(parse: &mut RegexpParse, qa: &mut QuantifiedAtom) -> Re
                 message: "invalid number in quantifier".into(),
                 offset: parse.last_index,
             })?;
+            if hi > REGEXP_QUANTIFIER_MAX {
+                return Err(quantifier_too_large_error(parse));
+            }
             if hi < qa.quant_min {
                 return Err(Error {
                     message: "invalid range quantifier, top must be greater than bottom".into(),

--- a/src/regexp/parser.rs
+++ b/src/regexp/parser.rs
@@ -1956,10 +1956,8 @@ fn read_range_quantifier(parse: &mut RegexpParse, qa: &mut QuantifiedAtom) -> Re
                 message: "invalid number in quantifier".into(),
                 offset: parse.last_index,
             })?;
-            // The NFA builder materializes one state per repetition, so an
-            // unbounded count would let a single pattern allocate an
-            // arbitrarily large automaton. Reject oversized counts here,
-            // before any states are built.
+            // The NFA builder materializes one state per repetition, so
+            // repetition counts must be bounded before any states are built.
             if lo > REGEXP_QUANTIFIER_MAX {
                 return Err(quantifier_too_large_error(parse));
             }

--- a/src/tests_operators.rs
+++ b/src/tests_operators.rs
@@ -1237,18 +1237,13 @@ fn test_range_quantifier_at_max_accepted() {
 }
 
 /// Miri-only: covers the gap left by skipping test_range_quantifier_at_max_accepted.
-/// The acceptance side of the bound is parser-level, so this pins it via
-/// parse_regexp without building the ~100-state NFAs (any count at the maximum
-/// materializes one state per repetition, which is slow under Miri). The
-/// general-expansion build path itself is covered at tiny scale by
-/// test_range_quantifier_larger_values.
+/// The bound is enforced in the parser, so parse_regexp alone pins acceptance;
+/// the build path runs at tiny scale in test_range_quantifier_larger_values.
 #[test]
 #[cfg(miri)]
 fn test_range_quantifier_at_max_accepted_miri() {
     use crate::regexp::parse_regexp;
 
-    // Counts at exactly REGEXP_QUANTIFIER_MAX are accepted, including the
-    // {n,} and {n,100} forms whose quant_max equals the +/* sentinel value.
     for rx in ["x{98,100}", "x{100}", "x{100,}"] {
         parse_regexp(rx).unwrap_or_else(|e| panic!("{rx} should be accepted, got: {e}"));
     }
@@ -1256,18 +1251,16 @@ fn test_range_quantifier_at_max_accepted_miri() {
 
 #[test]
 fn test_range_quantifier_over_max_rejected() {
-    // The NFA builds one state per repetition, so the parser must reject
-    // oversized counts before any automaton is constructed. The error must
-    // come from the regexp parser (cheap), not from a post-build memory
-    // budget check, and large counts must never panic.
+    // Oversized counts must be rejected by the parser, before the NFA
+    // builder allocates one state per repetition.
     let mut q = Quamina::<String>::new();
     for rx in [
-        "x{1,101}",   // one over the max in the upper bound
-        "x{101}",     // exact count over the max
-        "x{101,}",    // open-ended with oversized minimum
-        "x{101,200}", // both bounds oversized
-        "x{1,65535}", // builds an ~8 GB arena if it reaches the NFA builder
-        "x{1,65536}", // panics in the arena epsilon-closure path if built
+        "x{1,101}",   // one over the maximum
+        "x{101}",     // exact count
+        "x{101,}",    // open-ended minimum
+        "x{101,200}", // both bounds
+        "x{1,65535}", // large enough to allocate gigabytes if built
+        "x{1,65536}", // large enough to overflow the u16 epsilon-closure limit
     ] {
         let pattern = format!(r#"{{"v": [{{"regexp": "{rx}"}}]}}"#);
         let err = q

--- a/src/tests_operators.rs
+++ b/src/tests_operators.rs
@@ -1220,6 +1220,7 @@ fn test_wb_utf8_nonword_to_word() {
 // ============================================================================
 
 #[test]
+#[cfg_attr(miri, ignore)] // matching ~100-char strings through ~100-state NFAs is slow under Miri
 fn test_range_quantifier_at_max_accepted() {
     // Counts up to REGEXP_QUANTIFIER_MAX (100) are accepted, including the
     // {n,} and {n,100} forms whose quant_max equals the +/* sentinel value.
@@ -1233,6 +1234,24 @@ fn test_range_quantifier_at_max_accepted() {
     let q = q!("p" => r#"{"v": [{"regexp": "x{2,}"}]}"#);
     assert_has_match!(q, r#"{"v": "xxx"}"#, "p");
     assert_no_has_match!(q, r#"{"v": "x"}"#, "p");
+}
+
+/// Miri-only: covers the gap left by skipping test_range_quantifier_at_max_accepted.
+/// The acceptance side of the bound is parser-level, so this pins it via
+/// parse_regexp without building the ~100-state NFAs (any count at the maximum
+/// materializes one state per repetition, which is slow under Miri). The
+/// general-expansion build path itself is covered at tiny scale by
+/// test_range_quantifier_larger_values.
+#[test]
+#[cfg(miri)]
+fn test_range_quantifier_at_max_accepted_miri() {
+    use crate::regexp::parse_regexp;
+
+    // Counts at exactly REGEXP_QUANTIFIER_MAX are accepted, including the
+    // {n,} and {n,100} forms whose quant_max equals the +/* sentinel value.
+    for rx in ["x{98,100}", "x{100}", "x{100,}"] {
+        parse_regexp(rx).unwrap_or_else(|e| panic!("{rx} should be accepted, got: {e}"));
+    }
 }
 
 #[test]

--- a/src/tests_operators.rs
+++ b/src/tests_operators.rs
@@ -1216,6 +1216,52 @@ fn test_wb_utf8_nonword_to_word() {
 }
 
 // ============================================================================
+// Regexp Range Quantifier Bounds Tests
+// ============================================================================
+
+#[test]
+fn test_range_quantifier_at_max_accepted() {
+    // Counts up to REGEXP_QUANTIFIER_MAX (100) are accepted, including the
+    // {n,} and {n,100} forms whose quant_max equals the +/* sentinel value.
+    let q = q!("p" => r#"{"v": [{"regexp": "x{98,100}"}]}"#);
+    assert_has_match!(q, &format!(r#"{{"v": "{}"}}"#, "x".repeat(99)), "p");
+    assert_no_has_match!(q, r#"{"v": "x"}"#, "p");
+
+    let q = q!("p" => r#"{"v": [{"regexp": "x{100}"}]}"#);
+    assert_has_match!(q, &format!(r#"{{"v": "{}"}}"#, "x".repeat(100)), "p");
+
+    let q = q!("p" => r#"{"v": [{"regexp": "x{2,}"}]}"#);
+    assert_has_match!(q, r#"{"v": "xxx"}"#, "p");
+    assert_no_has_match!(q, r#"{"v": "x"}"#, "p");
+}
+
+#[test]
+fn test_range_quantifier_over_max_rejected() {
+    // The NFA builds one state per repetition, so the parser must reject
+    // oversized counts before any automaton is constructed. The error must
+    // come from the regexp parser (cheap), not from a post-build memory
+    // budget check, and large counts must never panic.
+    let mut q = Quamina::<String>::new();
+    for rx in [
+        "x{1,101}",   // one over the max in the upper bound
+        "x{101}",     // exact count over the max
+        "x{101,}",    // open-ended with oversized minimum
+        "x{101,200}", // both bounds oversized
+        "x{1,65535}", // builds an ~8 GB arena if it reaches the NFA builder
+        "x{1,65536}", // panics in the arena epsilon-closure path if built
+    ] {
+        let pattern = format!(r#"{{"v": [{{"regexp": "{rx}"}}]}}"#);
+        let err = q
+            .add_pattern("p".to_string(), &pattern)
+            .expect_err(&format!("{rx} should be rejected"));
+        assert!(
+            err.to_string().contains("quantifier"),
+            "{rx} should fail in the quantifier parser, got: {err}"
+        );
+    }
+}
+
+// ============================================================================
 // JSON Escape Sequences Tests
 // ============================================================================
 


### PR DESCRIPTION
An explicit `{n,m}` range quantifier wasn't checked against `REGEXP_QUANTIFIER_MAX` (100) — `+`, `*`, and `{n,}` are capped, but `{n,m}` and `{n}` wrote the count straight through to the NFA builder, which allocates one state per repetition. The memory budget only runs after the arena is built, so a single `add_pattern` call with `x{1,65535}` built an ~8.6 GB arena over ~16 seconds, and `x{1,65536}` panicked in epsilon-closure packing. The parser now rejects counts over the maximum on both bounds, so these patterns fail in ~12 µs with a normal `InvalidPattern` error and nothing gets allocated.

Go upstream writes the count through unchecked too, so there was no upstream behavior to match. Rejecting seemed better than clamping, since clamping would silently change what a pattern matches.

This also surfaced a wrong `debug_assert` in the NFA builder, which assumed `quant_max == REGEXP_QUANTIFIER_MAX` could only come from `+` or `*`. `{n,}` produces the same value whenever n > 1, so `x{2,}` panicked in every debug build. The assert now checks what the parser actually guarantees.

Tests cover the boundary (exactly 100, one over, the huge repro values) and `x{2,}`. The at-max test is skipped under Miri — matching ~100-char strings through ~100-state NFAs is slow there — with a parser-level twin covering the gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)