### PR TITLE
release: v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,25 +6,30 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 Style inspired by [ripgrep's CHANGELOG](https://github.com/BurntSushi/ripgrep/blob/master/CHANGELOG.md).
 
-## [Unreleased]
+## [0.6.0] — 2026-06-11
 
 ### Added
-- NFA→DFA subset construction at freeze time: regexp patterns with epsilon transitions are eagerly converted to DFA (budget: 8× NFA states, max 10k), with a lazy DFA fallback for patterns exceeding the eager budget (`regexp_plus_long`: 1259→501 ns, `regexp_star_long`: 1125→459 ns, `pathological_epsilon`: 6.08→2.00 µs)
+- `Quamina::get_memory_budget` / `Quamina::set_memory_budget`: inspect and adjust the memory cap at runtime; a budget of 0 disables the check. Ported from Go upstream PR #516 (#101)
+- NFA→DFA subset construction at freeze time: regexp patterns with epsilon transitions are eagerly converted to DFA (budget: 8× NFA states, max 10k), with a lazy DFA fallback for patterns exceeding the eager budget (`regexp_plus_long`: 1259→501 ns, `regexp_star_long`: 1125→459 ns, `pathological_epsilon`: 6.08→2.00 µs) (#90)
 - DFA acceleration: `compute_dfa_accel` detects self-loop states and attaches memchr skip info for SIMD byte skipping on patterns like `[^x]+`
 - Profiling examples for NFA→DFA budget tuning and negated char class acceleration
 - Allocation-free integration test for `traverse_arena_nfa` (counting global allocator, gated off Miri), expanded `dstep` hot-path documentation, and forbidden UTF-8 byte coverage tests (#100)
+- Incremental mutation-testing gate on PRs and `just mutants-local` for full-tree sweeps (#147, #148)
 
 ### Changed
+- Removed `SmallTable.default`; spinner states are now detected structurally. The smaller `FaState` improves cache density along the epsilon traversal (`pathological_epsilon`: 3.39 µs → 1.72 µs) (#128)
 - Tightened strict clippy lints: removed blanket allows for `module_name_repetitions`, `too_many_lines`, `similar_names`, and related structural/naming lints; refactored hot spots, kept per-item allows on hot loops and generated tables
 - Added `# Errors` sections to public fallible APIs and enabled `missing_errors_doc`
 - Removed unused `SmallTable::step` wrapper; `dstep` is the only stepping entry point
-- Synced Go upstream through commit e33139f
+- Expanded mutation test coverage across arena, parser, NFA, flatten_json, and matcher modules; closed all non-equivalent gaps in `arena.rs` and `regexp/parser.rs` (#84–#145)
+- Synced Go upstream through commit d951751
 
 ### Fixed
+- Explicit range quantifiers (`{n,m}`) are now bounded at parse time: counts above 100 are rejected as invalid patterns. Previously `x{1,65535}` built a multi-gigabyte arena before the memory budget could reject it, and `x{1,65536}` panicked. Also fixed a debug-build panic on open-ended quantifiers like `x{2,}` (#150)
 - `[^x]+` patterns (17K-state Unicode NFA) exceeded the DFA budget and regressed; SIMD acceleration via `AccelInfo::try_accelerate` restores performance (`regexp_negated_1k`: 3.2 µs → 652 ns)
 
 ### Breaking
-- Pattern parsing rejects unknown JSON escapes (e.g. `\z`), matching Go upstream's `readTextWithEscapes`
+- Pattern parsing rejects unknown JSON escapes (e.g. `\z`), matching Go upstream's `readTextWithEscapes` (#122)
 
 ## [0.5.0] — 2026-03-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,13 @@ Style inspired by [ripgrep's CHANGELOG](https://github.com/BurntSushi/ripgrep/bl
 ## [0.6.0] — 2026-06-11
 
 ### Added
-- `get_memory_budget` / `set_memory_budget` on `Quamina`: adjust the memory cap at runtime, 0 disables the check (ported from Go PR #516) (#101)
-- NFA→DFA subset construction at freeze time, with a lazy DFA fallback for patterns over budget (`regexp_plus_long`: 1259 ns → 501 ns, `pathological_epsilon`: 6.1 µs → 2.0 µs) (#90)
-- memchr acceleration for self-loop states like `[^x]+` (`regexp_negated_1k`: 3.2 µs → 652 ns) (#90)
+- (Beta) Ability to adjust the memory cap at runtime (ported from Go PR #516) (#101)
+- NFA→DFA subset construction with a lazy DFA fallback for patterns over budget, giving 2~3x improvement in some cases (`regexp_plus_long`: 1259 ns → 501 ns, `pathological_epsilon`: 6.1 µs → 2.0 µs) (#90)
+- memchr acceleration for self-loop states like `[^x]+` for more performance. (#90)
 - Mutation-testing gate on PRs, plus `just mutants-local` for full sweeps (#147, #148)
 
 ### Changed
-- Removed `SmallTable.default`; the smaller state struct speeds up epsilon traversal (`pathological_epsilon`: 3.4 µs → 1.7 µs) (#128)
+- Removed `SmallTable.default`. The smaller state struct speeds up epsilon traversal (#128)
 - Tightened strict clippy lints and added `# Errors` docs to public fallible APIs (#95–#99)
 - Expanded mutation test coverage across all modules (#83–#145)
 - Synced Go upstream through d951751

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,27 +9,22 @@ Style inspired by [ripgrep's CHANGELOG](https://github.com/BurntSushi/ripgrep/bl
 ## [0.6.0] — 2026-06-11
 
 ### Added
-- `Quamina::get_memory_budget` / `Quamina::set_memory_budget`: inspect and adjust the memory cap at runtime; a budget of 0 disables the check. Ported from Go upstream PR #516 (#101)
-- NFA→DFA subset construction at freeze time: regexp patterns with epsilon transitions are eagerly converted to DFA (budget: 8× NFA states, max 10k), with a lazy DFA fallback for patterns exceeding the eager budget (`regexp_plus_long`: 1259→501 ns, `regexp_star_long`: 1125→459 ns, `pathological_epsilon`: 6.08→2.00 µs) (#90)
-- DFA acceleration: `compute_dfa_accel` detects self-loop states and attaches memchr skip info for SIMD byte skipping on patterns like `[^x]+`
-- Profiling examples for NFA→DFA budget tuning and negated char class acceleration
-- Allocation-free integration test for `traverse_arena_nfa` (counting global allocator, gated off Miri), expanded `dstep` hot-path documentation, and forbidden UTF-8 byte coverage tests (#100)
-- Incremental mutation-testing gate on PRs and `just mutants-local` for full-tree sweeps (#147, #148)
+- `get_memory_budget` / `set_memory_budget` on `Quamina`: adjust the memory cap at runtime, 0 disables the check (ported from Go PR #516) (#101)
+- NFA→DFA subset construction at freeze time, with a lazy DFA fallback for patterns over budget (`regexp_plus_long`: 1259 ns → 501 ns, `pathological_epsilon`: 6.1 µs → 2.0 µs) (#90)
+- memchr acceleration for self-loop states like `[^x]+` (`regexp_negated_1k`: 3.2 µs → 652 ns) (#90)
+- Mutation-testing gate on PRs, plus `just mutants-local` for full sweeps (#147, #148)
 
 ### Changed
-- Removed `SmallTable.default`; spinner states are now detected structurally. The smaller `FaState` improves cache density along the epsilon traversal (`pathological_epsilon`: 3.39 µs → 1.72 µs) (#128)
-- Tightened strict clippy lints: removed blanket allows for `module_name_repetitions`, `too_many_lines`, `similar_names`, and related structural/naming lints; refactored hot spots, kept per-item allows on hot loops and generated tables
-- Added `# Errors` sections to public fallible APIs and enabled `missing_errors_doc`
-- Removed unused `SmallTable::step` wrapper; `dstep` is the only stepping entry point
-- Expanded mutation test coverage across arena, parser, NFA, flatten_json, and matcher modules; closed all non-equivalent gaps in `arena.rs` and `regexp/parser.rs` (#84–#145)
-- Synced Go upstream through commit d951751
+- Removed `SmallTable.default`; the smaller state struct speeds up epsilon traversal (`pathological_epsilon`: 3.4 µs → 1.7 µs) (#128)
+- Tightened strict clippy lints and added `# Errors` docs to public fallible APIs (#95–#99)
+- Expanded mutation test coverage across all modules (#83–#145)
+- Synced Go upstream through d951751
 
 ### Fixed
-- Explicit range quantifiers (`{n,m}`) are now bounded at parse time: counts above 100 are rejected as invalid patterns. Previously `x{1,65535}` built a multi-gigabyte arena before the memory budget could reject it, and `x{1,65536}` panicked. Also fixed a debug-build panic on open-ended quantifiers like `x{2,}` (#150)
-- `[^x]+` patterns (17K-state Unicode NFA) exceeded the DFA budget and regressed; SIMD acceleration via `AccelInfo::try_accelerate` restores performance (`regexp_negated_1k`: 3.2 µs → 652 ns)
+- Range quantifiers (`{n,m}`) now reject counts above 100 at parse time; huge counts previously built multi-gigabyte arenas or panicked (#150)
 
 ### Breaking
-- Pattern parsing rejects unknown JSON escapes (e.g. `\z`), matching Go upstream's `readTextWithEscapes` (#122)
+- Pattern parsing rejects unknown JSON escapes like `\z`, matching Go upstream (#122)
 
 ## [0.5.0] — 2026-03-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Style inspired by [ripgrep's CHANGELOG](https://github.com/BurntSushi/ripgrep/bl
 - Tightened strict clippy lints and added `# Errors` docs to public fallible APIs (#95–#99)
 - Expanded mutation test coverage across all modules (#83–#145)
 - Synced Go upstream through d951751
+- Declared minimum supported Rust version: 1.88
 
 ### Fixed
 - Range quantifiers (`{n,m}`) now reject counts above 100 at parse time; huge counts previously built multi-gigabyte arenas or panicked (#150)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "quamina"
 version = "0.6.0"
 edition = "2024"
+rust-version = "1.88"
 description = "Fast pattern-matching library for filtering JSON events"
 license = "Apache-2.0"
 repository = "https://github.com/baldawarishi/quamina-rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quamina"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2024"
 description = "Fast pattern-matching library for filtering JSON events"
 license = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -224,12 +224,12 @@ Matching time is nearly independent of pattern count. All patterns compile into 
 
 ### Pattern count scaling
 
-On an M3 Max:
+On an M4 Max:
 
 | Patterns | Match time |
 |----------|-----------|
-| 100 | ~115 ns |
-| 10,000 | ~100 ns |
+| 100 | ~110 ns |
+| 10,000 | ~90 ns |
 
 Matching time is sublinear in pattern count because all patterns share one automaton.
 
@@ -237,22 +237,22 @@ Matching time is sublinear in pattern count because all patterns share one autom
 
 | Benchmark | Time | Description |
 |-----------|-----:|-------------|
-| citylots | ~1,600 ns | 4 patterns, 206 KB of GeoJSON |
-| nested field match | ~5,100 ns | 5 KB JSON, deeply nested field |
-| early field exit | ~220 ns | 14 KB JSON, matching field near the top |
+| citylots | ~1,400 ns | 4 patterns, 206 KB of GeoJSON |
+| nested field match | ~4,400 ns | 9 KB JSON, deeply nested field |
+| early field exit | ~180 ns | 9 KB JSON, matching field near the top |
 
 ### Pattern type benchmarks
 
 | Benchmark | Time | Description |
 |---|---:|---|
-| exact_match | ~70 ns | Single exact match |
-| nested_match | ~103 ns | Exact match on a nested key |
-| regex_match | ~60 ns | Simple regex (eager DFA after compile) |
-| anything_but_match | ~83 ns | `anything-but` with 3 excluded values |
-| numeric_range_two_sided | ~89 ns | Two-sided range (`>= 0, < 100`) |
-| 100_prefix_patterns | ~120 ns | 100 `prefix` patterns merged into one automaton |
-| shellstyle_26_patterns | ~105 ns | 26 shellstyle patterns (A\*–Z\*) |
-| regexp_plus_long | ~340 ns | `[a-z]+` on a 100-char value |
+| exact_match | ~56 ns | Single exact match |
+| nested_match | ~83 ns | Exact match on a nested key |
+| regex_match | ~48 ns | Simple regex (eager DFA after compile) |
+| anything_but_match | ~65 ns | `anything-but` with 3 excluded values |
+| numeric_range_two_sided | ~72 ns | Two-sided range (`>= 0, < 100`) |
+| 100_prefix_patterns | ~117 ns | 100 `prefix` patterns merged into one automaton |
+| shellstyle_26_patterns | ~97 ns | 26 shellstyle patterns (A\*–Z\*) |
+| regexp_plus_long | ~260 ns | `[a-z]+` on a 100-char value |
 
 ### What affects performance
 


### PR DESCRIPTION
Bump to v0.6.0. Headline is the regexp engine work: NFA→DFA subset construction at freeze time (#90) plus the SmallTable shrink (#128) got pathological_epsilon from 6.1µs to 1.7µs, and most regexp benches are 20–35% faster.

Also includes the `{n,m}` quantifier fix (#150) — huge counts used to build multi-gigabyte arenas or panic before the budget could kick in — the runtime memory-budget API from Go #516 (#101), strict clippy (#95–#99), and the mutation-testing campaign (#83–#148). Minor bump rather than patch because patterns with unknown JSON escapes like `\z` are now rejected (#122).

Re-ran the README benchmark numbers while at it. Full changelog in CHANGELOG.md. After merge: tag v0.6.0, then `just publish`.
