### PR TITLE
Add add_pattern scaling benchmarks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,10 @@ name = "bulk_10k"
 harness = false
 
 [[bench]]
+name = "add_pattern_scaling"
+harness = false
+
+[[bench]]
 name = "memory"
 harness = false
 

--- a/benches/add_pattern_scaling.rs
+++ b/benches/add_pattern_scaling.rs
@@ -1,0 +1,121 @@
+//! Scaling benchmark for incremental pattern addition.
+//!
+//! Run locally with:
+//! cargo bench --bench add_pattern_scaling
+//!
+//! Criterion will render wall-time-vs-K plots in target/criterion. The
+//! `prefix_same_field` case exercises the arena merge path used by
+//! `merge_into_main_arena`; `exact_same_field` is a control for the in-place
+//! string insertion path.
+
+use std::hint::black_box;
+use std::time::Duration;
+
+use criterion::{
+    BenchmarkId, Criterion, PlotConfiguration, Throughput, criterion_group, criterion_main,
+};
+use quamina::Quamina;
+
+const PATTERN_COUNTS: [usize; 8] = [64, 128, 256, 512, 1_024, 2_048, 4_096, 8_192];
+
+fn exact_patterns(count: usize) -> Vec<String> {
+    (0..count)
+        .map(|i| format!(r#"{{"field": ["value_{i:06}"]}}"#))
+        .collect()
+}
+
+fn prefix_patterns(count: usize) -> Vec<String> {
+    (0..count)
+        .map(|i| format!(r#"{{"field": [{{"prefix": "value_{i:06}"}}]}}"#))
+        .collect()
+}
+
+fn add_patterns(patterns: &[String]) {
+    let mut q = Quamina::<usize>::new();
+    for (i, pattern) in patterns.iter().enumerate() {
+        q.add_pattern(i, black_box(pattern.as_str())).unwrap();
+    }
+    black_box(q);
+}
+
+fn add_patterns_then_first_match(patterns: &[String], event: &[u8]) {
+    let mut q = Quamina::<usize>::new();
+    for (i, pattern) in patterns.iter().enumerate() {
+        q.add_pattern(i, black_box(pattern.as_str())).unwrap();
+    }
+    let build_stats = q.matcher_stats();
+    let matches = q.matches_for_event(black_box(event)).unwrap();
+    let frozen_stats = q.arena_stats();
+    black_box((q, build_stats, matches, frozen_stats));
+}
+
+fn bench_add_pattern_scaling(c: &mut Criterion) {
+    let mut group = c.benchmark_group("add_pattern_scaling");
+    group.plot_config(PlotConfiguration::default());
+
+    for count in PATTERN_COUNTS {
+        let patterns = prefix_patterns(count);
+        group.throughput(Throughput::Elements(
+            u64::try_from(count).expect("pattern count fits in u64"),
+        ));
+        group.bench_with_input(
+            BenchmarkId::new("prefix_same_field", count),
+            &patterns,
+            |b, patterns| b.iter(|| add_patterns(black_box(patterns))),
+        );
+    }
+
+    for count in PATTERN_COUNTS {
+        let patterns = prefix_patterns(count);
+        let event = format!(r#"{{"field": "value_{:06}_tail"}}"#, count - 1).into_bytes();
+        group.throughput(Throughput::Elements(
+            u64::try_from(count).expect("pattern count fits in u64"),
+        ));
+        group.bench_with_input(
+            BenchmarkId::new("prefix_add_then_first_match", count),
+            &(patterns, event),
+            |b, (patterns, event)| {
+                b.iter(|| add_patterns_then_first_match(black_box(patterns), black_box(event)));
+            },
+        );
+    }
+
+    for count in PATTERN_COUNTS {
+        let patterns = exact_patterns(count);
+        group.throughput(Throughput::Elements(
+            u64::try_from(count).expect("pattern count fits in u64"),
+        ));
+        group.bench_with_input(
+            BenchmarkId::new("exact_same_field", count),
+            &patterns,
+            |b, patterns| b.iter(|| add_patterns(black_box(patterns))),
+        );
+    }
+
+    for count in PATTERN_COUNTS {
+        let patterns = exact_patterns(count);
+        let event = format!(r#"{{"field": "value_{:06}"}}"#, count - 1).into_bytes();
+        group.throughput(Throughput::Elements(
+            u64::try_from(count).expect("pattern count fits in u64"),
+        ));
+        group.bench_with_input(
+            BenchmarkId::new("exact_add_then_first_match", count),
+            &(patterns, event),
+            |b, (patterns, event)| {
+                b.iter(|| add_patterns_then_first_match(black_box(patterns), black_box(event)));
+            },
+        );
+    }
+
+    group.finish();
+}
+
+criterion_group! {
+    name = add_pattern_scaling;
+    config = Criterion::default()
+        .sample_size(10)
+        .measurement_time(Duration::from_secs(5))
+        .warm_up_time(Duration::from_secs(1));
+    targets = bench_add_pattern_scaling
+}
+criterion_main!(add_pattern_scaling);

--- a/examples/add_pattern_scaling_stats.rs
+++ b/examples/add_pattern_scaling_stats.rs
@@ -1,0 +1,59 @@
+use std::env;
+use std::time::Instant;
+
+use quamina::Quamina;
+
+fn exact_pattern(i: usize) -> String {
+    format!(r#"{{"field": ["value_{i:06}"]}}"#)
+}
+
+fn prefix_pattern(i: usize) -> String {
+    format!(r#"{{"field": [{{"prefix": "value_{i:06}"}}]}}"#)
+}
+
+fn run_scenario(name: &str, count: usize, pattern: fn(usize) -> String, event: Vec<u8>) {
+    let mut q = Quamina::<usize>::new();
+
+    let add_start = Instant::now();
+    for i in 0..count {
+        q.add_pattern(i, &pattern(i)).unwrap();
+    }
+    let add_ms = add_start.elapsed().as_secs_f64() * 1_000.0;
+    let build_stats = q.matcher_stats();
+
+    let first_match_start = Instant::now();
+    let matches = q.matches_for_event(&event).unwrap();
+    let first_match_ms = first_match_start.elapsed().as_secs_f64() * 1_000.0;
+    let frozen_stats = q.arena_stats();
+
+    println!(
+        "{name},{count},{add_ms:.3},{first_match_ms:.3},{},{},{},{},{}",
+        build_stats.states,
+        build_stats.bytes,
+        frozen_stats.state_count,
+        frozen_stats.estimated_bytes,
+        matches.len()
+    );
+}
+
+fn main() {
+    let count = env::args().nth(1).map_or(8_192, |arg| {
+        arg.parse().expect("count must be a positive integer")
+    });
+
+    println!(
+        "scenario,count,add_ms,first_match_ms,build_states,build_bytes,frozen_states,frozen_bytes,matches"
+    );
+    run_scenario(
+        "prefix_same_field",
+        count,
+        prefix_pattern,
+        format!(r#"{{"field": "value_{:06}_tail"}}"#, count - 1).into_bytes(),
+    );
+    run_scenario(
+        "exact_same_field",
+        count,
+        exact_pattern,
+        format!(r#"{{"field": "value_{:06}"}}"#, count - 1).into_bytes(),
+    );
+}


### PR DESCRIPTION
This PR adds baseline measurement for add_pattern scaling before changing matcher behavior.

It adds a Criterion benchmark for adding many patterns on the same field, covering both prefix patterns and exact string patterns. It also measures the first match after building, since that forces the mutable matcher to freeze.

There is also a small stats example that prints CSV output for quick local comparisons of add time, first-match time, build stats, frozen arena stats, and match count.

No matcher behavior changes are included here. This is just the measurement PR for the later optimization work.

Tested with:

cargo bench --bench add_pattern_scaling
cargo test --lib
cargo clippy --all-targets --all-features -- -D warnings
cargo fmt -- --check