### PR TITLE
ci: replace rustsec/audit-check with direct cargo audit

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -98,10 +98,12 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - name: Generate Cargo.lock
         run: cargo generate-lockfile
-      - name: Security audit
-        uses: rustsec/audit-check@v2
+      - name: Install cargo-audit
+        uses: taiki-e/install-action@v2
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          tool: cargo-audit
+      - name: Security audit
+        run: cargo audit
       - name: Check licenses and bans
         uses: EmbarkStudios/cargo-deny-action@v2
         with:


### PR DESCRIPTION
The `security` job logs a deprecation warning on every run: `rustsec/audit-check@v2` targets Node.js 20, which GitHub Actions now forces onto Node.js 24.

The fix for this is merged upstream (rustsec/audit-check#48, "Update to use Node 24"), but it has not been released. The `v2` and `v2.0.0` tags still point at the 2024 commit that declares `node20`, so there is no tag to bump to and the only mutable-tag option would be pinning to an unreleased master SHA.

Instead of depending on an unreleased commit, this drops the action and runs the audit directly: install `cargo-audit` via `taiki-e/install-action` (a composite action with no Node runtime, so no deprecation) and run `cargo audit`. Behavior is unchanged — it scans `Cargo.lock` for advisories and fails CI on vulnerabilities — and it matches how every other job in this workflow invokes cargo directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)