### PR TITLE
fix: resolve word boundaries past atoms that match no characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Style inspired by [ripgrep's CHANGELOG](https://github.com/BurntSushi/ripgrep/bl
 - `matcher_stats()` now measures the materialized (frozen) matcher, so it reflects the build mode — `BuiltForSpeed` reports the converted DFAs — letting you watch the size effect of the mode you chose (#178)
 
 ### Changed
+- Word boundary expansion now rejects a pattern whose boundaries expand past 1024 alternatives instead of building an automaton for every one of them (#188)
 - Default to `BuiltForComfort`, keeping wildcard and regexp matchers as NFAs; the NFA→DFA conversion now runs only under `BuiltForSpeed`. This favors cheaper `add_pattern` over faster `matches_for_event`, matching Go upstream's default (#178)
 - Store self-only epsilon closures as an implicit zero-length sentinel, avoiding one `StateId` in the flattened closure buffer for the common case (#173)
 - Precompute epsilon closures incrementally, re-closing only the states an added pattern introduces instead of the whole automaton on every add (matching Go upstream's `closureForNfa` prune) (#173)
@@ -26,6 +27,7 @@ Style inspired by [ripgrep's CHANGELOG](https://github.com/BurntSushi/ripgrep/bl
 - Removed the runtime memory-budget API (`get_memory_budget`/`set_memory_budget`), matching Go upstream dropping it; the build-time `QuaminaBuilder::with_arena_byte_budget` cap remains (#152)
 
 ### Fixed
+- A `{0}` quantifier beside a word boundary (`xa{0}~b `) no longer panics `add_pattern`, and an atom that can match zero characters now hands the boundary to its neighbour instead of assuming the value edge, so `xa?~b ` matches `x ` (#188)
 - Lookaround regexps now match against the value itself, not just their assertions: `foo(?!bar)baz` no longer matches `totally-unrelated`, `(?=.*foo).*bar.*` matches `foobar`, and `(?<=foo)bar(?=baz)baz` matches `foobarbaz` (#182, #183, #184)
 - `BuiltForSpeed` now holds its freeze-time DFA to the arena byte budget, keeping the NFA when there is no room, and applies to lookaround regexps, which it used to leave as NFAs (#186, #188)
 - `matcher_stats()` and `arena_stats()` now count the lazy DFA cache a `BuiltForSpeed` pattern falls back to, and the cache no longer allocates a transition table for states it declines to cache (#185, #186)

--- a/src/regexp/mod.rs
+++ b/src/regexp/mod.rs
@@ -1381,7 +1381,8 @@ mod tests {
     fn test_range_quantifier_equivalence_plus() {
         use crate::automaton::arena::{ARENA_VALUE_TERMINATOR, NfaBuffers, traverse_arena_nfa};
 
-        // a{1,} should be equivalent to a+ (but capped at REGEXP_QUANTIFIER_MAX)
+        // a{1,} and a+ are both unbounded: each builds the same cyclic loop,
+        // which never consults quant_max.
         let root_range = parse_regexp("a{1,}").unwrap();
         let root_plus = parse_regexp("a+").unwrap();
 
@@ -1437,7 +1438,8 @@ mod tests {
     fn test_range_quantifier_equivalence_star() {
         use crate::automaton::arena::{ARENA_VALUE_TERMINATOR, NfaBuffers, traverse_arena_nfa};
 
-        // a{0,} should be equivalent to a* (but capped at REGEXP_QUANTIFIER_MAX)
+        // a{0,} and a* are both unbounded: each builds the same cyclic loop,
+        // which never consults quant_max.
         let root_range = parse_regexp("a{0,}").unwrap();
         let root_star = parse_regexp("a*").unwrap();
 

--- a/src/regexp/parser.rs
+++ b/src/regexp/parser.rs
@@ -548,11 +548,9 @@ enum ConstrainedAtom {
     /// Quantified atom that needs splitting: (base_quantified, constrained_single)
     /// Used when we need to constrain only the last/first char of a quantified run.
     Split(QuantifiedAtom, QuantifiedAtom),
-    /// Quantified atom with quant_min=0 (can match zero chars).
-    /// First element: Split(base, constrained) for when atom matches 1+ chars.
-    /// The caller must also generate a branch where this atom is absent entirely
-    /// (for the zero-match case where the boundary is at the value edge).
-    SplitOrAbsent(QuantifiedAtom, QuantifiedAtom),
+    /// A `{0}` atom: it can never match a character, so it contributes nothing
+    /// and the boundary has to look at its neighbour instead.
+    Absent,
 }
 
 /// Constrain an atom's character class at a word boundary position.
@@ -568,6 +566,11 @@ fn constrain_atom_at_boundary(
     class: &RuneRange,
     is_last_char: bool,
 ) -> Option<ConstrainedAtom> {
+    if atom.quant_max == 0 {
+        // `{0}`: the atom matches no characters at all, so its class is moot.
+        return Some(ConstrainedAtom::Absent);
+    }
+
     if atom.subtree.is_some() {
         // Group atom — can't easily intersect
         return None;
@@ -620,7 +623,8 @@ fn constrain_atom_at_boundary(
     );
 
     if new_max == 0 {
-        // The quantified atom was {1,1} effectively → just the constrained single
+        // Splitting off the boundary-adjacent char used up the atom's only
+        // occurrence (`a?`), so all that is left is that constrained char.
         return Some(ConstrainedAtom::Single(constrained_single));
     }
 
@@ -634,31 +638,34 @@ fn constrain_atom_at_boundary(
         ..Default::default()
     };
 
-    // If the original atom can match zero times (quant_min == 0, e.g., * or ?),
-    // then the atom might be absent entirely, meaning the boundary is at the
-    // value edge (where `"` is non-word). Return SplitOrAbsent so the caller
-    // can generate an additional branch without this atom.
-    if atom.quant_min == 0 {
-        Some(ConstrainedAtom::SplitOrAbsent(base, constrained_single))
-    } else {
-        Some(ConstrainedAtom::Split(base, constrained_single))
+    Some(ConstrainedAtom::Split(base, constrained_single))
+}
+
+/// The atoms a constrained atom contributes to a branch, or `None` when it
+/// contributes none because it can never match.
+/// `base_first=true` gives [base, single] (prefix/last-char side),
+/// `base_first=false` gives [single, base] (suffix/first-char side).
+fn expand_constrained(ca: &ConstrainedAtom, base_first: bool) -> Option<Vec<QuantifiedAtom>> {
+    match ca {
+        ConstrainedAtom::Single(a) => Some(vec![a.clone()]),
+        ConstrainedAtom::Split(base, single) => Some(if base_first {
+            vec![base.clone(), single.clone()]
+        } else {
+            vec![single.clone(), base.clone()]
+        }),
+        ConstrainedAtom::Absent => None,
     }
 }
 
-/// Expand a constrained atom into atom sequences.
-/// `base_first=true` gives [base, single] (prefix/last-char side),
-/// `base_first=false` gives [single, base] (suffix/first-char side).
-fn expand_constrained(ca: &ConstrainedAtom, base_first: bool) -> Vec<Vec<QuantifiedAtom>> {
-    match ca {
-        ConstrainedAtom::Single(a) => vec![vec![a.clone()]],
-        ConstrainedAtom::Split(base, single) | ConstrainedAtom::SplitOrAbsent(base, single) => {
-            if base_first {
-                vec![vec![base.clone(), single.clone()]]
-            } else {
-                vec![vec![single.clone(), base.clone()]]
-            }
-        }
-    }
+/// Whether a word boundary can resolve past this atom, i.e. whether the atom
+/// may contribute no character for the boundary to test.
+///
+/// A `{0}` atom never contributes one. `?`, `*` and `{0,n}` also have a present
+/// case, which only gets expanded for atoms whose character class can be
+/// intersected — skipping past an optional group would silently drop its
+/// present case, so groups stay put and the boundary is reported as impossible.
+const fn boundary_may_skip_atom(atom: &QuantifiedAtom) -> bool {
+    atom.quant_max == 0 || (atom.quant_min == 0 && atom.subtree.is_none())
 }
 
 /// Expand a `~b`/`~B` at value start (no prefix atoms before the boundary).
@@ -674,25 +681,13 @@ fn expand_wb_at_start(suffix: &[QuantifiedAtom], is_boundary: bool, out: &mut Ve
     let Some(constrained) = constrain_atom_at_boundary(&suffix[0], required_class, false) else {
         return;
     };
+    let Some(atoms) = expand_constrained(&constrained, false) else {
+        return;
+    };
 
-    for atoms in expand_constrained(&constrained, false) {
-        let mut branch = atoms;
-        branch.extend_from_slice(&suffix[1..]);
-        out.push(branch);
-    }
-
-    // SplitOrAbsent: the first suffix atom matched 0 chars, so the boundary
-    // falls at value start. Constrain the next real atom instead.
-    if matches!(constrained, ConstrainedAtom::SplitOrAbsent(..))
-        && suffix.len() > 1
-        && let Some(c2) = constrain_atom_at_boundary(&suffix[1], required_class, false)
-    {
-        for atoms in expand_constrained(&c2, false) {
-            let mut branch = atoms;
-            branch.extend_from_slice(&suffix[2..]);
-            out.push(branch);
-        }
-    }
+    let mut branch = atoms;
+    branch.extend_from_slice(&suffix[1..]);
+    out.push(branch);
 }
 
 /// Expand a `~b`/`~B` at value end (no suffix atoms after the boundary).
@@ -710,25 +705,13 @@ fn expand_wb_at_end(prefix: &[QuantifiedAtom], is_boundary: bool, out: &mut Vec<
     else {
         return;
     };
+    let Some(atoms) = expand_constrained(&constrained, true) else {
+        return;
+    };
 
-    for atoms in expand_constrained(&constrained, true) {
-        let mut branch = prefix[..last_idx].to_vec();
-        branch.extend(atoms);
-        out.push(branch);
-    }
-
-    // SplitOrAbsent: last prefix atom matched 0 chars, so boundary falls
-    // at the end after the preceding atom. Constrain that one instead.
-    if matches!(constrained, ConstrainedAtom::SplitOrAbsent(..)) && last_idx > 0 {
-        let prev = last_idx - 1;
-        if let Some(c2) = constrain_atom_at_boundary(&prefix[prev], required_class, true) {
-            for atoms in expand_constrained(&c2, true) {
-                let mut branch = prefix[..prev].to_vec();
-                branch.extend(atoms);
-                out.push(branch);
-            }
-        }
-    }
+    let mut branch = prefix[..last_idx].to_vec();
+    branch.extend(atoms);
+    out.push(branch);
 }
 
 /// Expand a `~b`/`~B` in the middle (between prefix and suffix atoms).
@@ -760,46 +743,83 @@ fn expand_wb_in_middle(
         let (Some(cl), Some(cf)) = (&cl, &cf) else {
             continue;
         };
+        let (Some(pe), Some(se)) = (expand_constrained(cl, true), expand_constrained(cf, false))
+        else {
+            continue;
+        };
 
-        // Generate all combinations from constrained prefix × suffix
-        for pe in &expand_constrained(cl, true) {
-            for se in &expand_constrained(cf, false) {
-                let mut branch = prefix[..last_idx].to_vec();
-                branch.extend(pe.clone());
-                branch.extend(se.clone());
-                branch.extend_from_slice(&suffix[1..]);
-                out.push(branch);
-            }
-        }
-
-        // SplitOrAbsent on prefix side: prefix atom absent → boundary at value start.
-        // The `"` is non-word, so constrain suffix to edge class.
-        if matches!(cl, ConstrainedAtom::SplitOrAbsent(..)) {
-            let edge_class = if is_boundary { &wc } else { &nwc };
-            if let Some(c2) = constrain_atom_at_boundary(&suffix[0], edge_class, false) {
-                for se in expand_constrained(&c2, false) {
-                    let mut branch = prefix[..last_idx].to_vec();
-                    branch.extend(se);
-                    branch.extend_from_slice(&suffix[1..]);
-                    out.push(branch);
-                }
-            }
-        }
-
-        // SplitOrAbsent on suffix side: suffix atom absent → boundary at value end.
-        if matches!(cf, ConstrainedAtom::SplitOrAbsent(..)) {
-            let edge_class = if is_boundary { &wc } else { &nwc };
-            if let Some(c2) = constrain_atom_at_boundary(&prefix[last_idx], edge_class, true) {
-                for pe in expand_constrained(&c2, true) {
-                    let mut branch = prefix[..last_idx].to_vec();
-                    branch.extend(pe);
-                    branch.extend_from_slice(&suffix[1..]);
-                    out.push(branch);
-                }
-            }
-        }
+        let mut branch = prefix[..last_idx].to_vec();
+        branch.extend(pe);
+        branch.extend(se);
+        branch.extend_from_slice(&suffix[1..]);
+        out.push(branch);
     }
 }
+
+/// Expand one `~b`/`~B` against the atoms on either side of it, appending one
+/// alternative branch per way the boundary can be satisfied.
+///
+/// The atom next to the boundary may match zero characters (`a?`, `a*`) or
+/// never match at all (`a{0}`). When it matches none, it leaves no character
+/// for the boundary to test and the boundary resolves against the next atom
+/// along instead, with the absent atom dropped from the branch. Both sides walk
+/// outwards over such atoms, so every combination of present and absent
+/// neighbours becomes its own alternative.
+fn expand_wb_atoms(
+    prefix_atoms: &[QuantifiedAtom],
+    suffix_atoms: &[QuantifiedAtom],
+    is_boundary: bool,
+    out: &mut Vec<Branch>,
+) {
+    let mut prefix = prefix_atoms;
+    loop {
+        let mut suffix = suffix_atoms;
+        loop {
+            // Give up the moment the walk is over budget; the caller turns an
+            // over-long `out` into a rejected pattern.
+            if out.len() > MAX_WB_ALTERNATIVES {
+                return;
+            }
+
+            match (prefix.is_empty(), suffix.is_empty()) {
+                // Both sides are the `"` delimiter, which is non-word: two
+                // non-word chars are never a boundary and always a non-boundary.
+                (true, true) => {
+                    if !is_boundary {
+                        out.push(Vec::new());
+                    }
+                }
+                (true, false) => expand_wb_at_start(suffix, is_boundary, out),
+                (false, true) => expand_wb_at_end(prefix, is_boundary, out),
+                (false, false) => expand_wb_in_middle(prefix, suffix, is_boundary, out),
+            }
+
+            let Some((first, rest)) = suffix.split_first() else {
+                break;
+            };
+            if !boundary_may_skip_atom(first) {
+                break;
+            }
+            suffix = rest;
+        }
+
+        let Some((last, rest)) = prefix.split_last() else {
+            break;
+        };
+        if !boundary_may_skip_atom(last) {
+            break;
+        }
+        prefix = rest;
+    }
+}
+
+/// Cap on the branches one pattern's word boundaries may expand into.
+///
+/// Every boundary multiplies the branch count by the ways the atoms around it
+/// can be present or absent, and each branch is later materialized into its own
+/// run of NFA states. Refusing the pattern keeps a short string of optional
+/// atoms around a boundary from building an enormous automaton.
+const MAX_WB_ALTERNATIVES: usize = 1024;
 
 /// Expand word boundaries (`~b`/`~B`) in a regexp tree using character-class intersection.
 ///
@@ -842,19 +862,11 @@ pub fn expand_word_boundaries(tree: &Root) -> Result<Root, String> {
 
                 let prefix = &alt[..pos];
                 let suffix = &alt[pos + 1..];
-
-                match (prefix.is_empty(), suffix.is_empty()) {
-                    (true, true) => {
-                        // ~b alone: between two `"` (non-word). Boundary = never, non-boundary = always.
-                        if !is_boundary {
-                            new_alternatives.push(Vec::new());
-                        }
-                    }
-                    (true, false) => expand_wb_at_start(suffix, is_boundary, &mut new_alternatives),
-                    (false, true) => expand_wb_at_end(prefix, is_boundary, &mut new_alternatives),
-                    (false, false) => {
-                        expand_wb_in_middle(prefix, suffix, is_boundary, &mut new_alternatives);
-                    }
+                expand_wb_atoms(prefix, suffix, is_boundary, &mut new_alternatives);
+                if new_alternatives.len() > MAX_WB_ALTERNATIVES {
+                    return Err(format!(
+                        "word boundary expansion exceeds {MAX_WB_ALTERNATIVES} alternatives"
+                    ));
                 }
             }
 
@@ -2531,7 +2543,7 @@ mod tests {
 
     #[test]
     fn test_wb_quantified_star_at_end() {
-        // x.*~b — star before boundary at end, triggers SplitOrAbsent path
+        // x.*~b — star before boundary at end, so .* may be absent.
         // When .* matches 0 chars, boundary falls after 'x' (word → non-word " = valid)
         let tree = parse("x.*~b").unwrap();
         let expanded = expand_word_boundaries(&tree).unwrap();
@@ -2540,21 +2552,21 @@ mod tests {
         // 2. x alone (when .* is absent, 'x' is word, " is non-word → boundary)
         assert!(
             expanded.len() >= 2,
-            "x.*~b should produce SplitOrAbsent branches, got {}",
+            "x.*~b should produce both the present and absent branches, got {}",
             expanded.len()
         );
     }
 
     #[test]
     fn test_wb_star_at_start() {
-        // ~ba*x — star-quantified 'a' at boundary start, triggers SplitOrAbsent
-        // in expand_wb_at_start. When a* matches 0 chars, boundary falls before 'x'.
+        // ~ba*x — star-quantified 'a' at boundary start, so a* may be absent.
+        // When a* matches 0 chars, the boundary falls before 'x' instead.
         let tree = parse("~ba*x").unwrap();
         let expanded = expand_word_boundaries(&tree).unwrap();
         // Should produce branches for both: a present (constrained) and a absent (x constrained)
         assert!(
             expanded.len() >= 2,
-            "~ba*x should produce SplitOrAbsent branches at start, got {}",
+            "~ba*x should produce both the present and absent branches, got {}",
             expanded.len()
         );
     }
@@ -2625,22 +2637,21 @@ mod tests {
     }
 
     // ========================================================================
-    // Word boundary with SplitOrAbsent fallback (expand_wb_at_end)
+    // Word boundary against an atom that may be absent (expand_wb_at_end)
     // ========================================================================
 
     #[test]
     fn test_wb_at_end_with_star_after_literal() {
-        // xa*~b — 'x' is a word char, 'a*' can match zero chars (SplitOrAbsent).
+        // xa*~b — 'x' is a word char and 'a*' can match zero chars.
         // When a* is absent, boundary falls after 'x' (word → non-word " = valid).
         // When a* is present, its last char must be word (trivially true for 'a').
-        // The SplitOrAbsent path constrains the preceding atom ('x') as fallback.
         let tree = parse("xa*~b").unwrap();
         let expanded = expand_word_boundaries(&tree).unwrap();
         // Must produce branches for both the present case (a* constrained) and
-        // the absent case (x constrained as fallback)
+        // the absent case (the boundary resolving against 'x')
         assert!(
             expanded.len() >= 2,
-            "xa*~b needs SplitOrAbsent fallback branches, got {}",
+            "xa*~b needs a branch for a* present and one for a* absent, got {}",
             expanded.len()
         );
     }
@@ -2674,9 +2685,8 @@ mod tests {
     #[test]
     fn test_wb_single_star_at_end() {
         // .*~b — single zero-or-more atom before boundary at end.
-        // Prefix is [.*] (last_idx = 0). SplitOrAbsent path must NOT
-        // try to access prefix[-1]; the fallback is skipped when there is
-        // no preceding atom.
+        // The prefix is [.*], so when .* is absent the boundary has no
+        // preceding atom left to resolve against and lands at value start.
         let tree = parse(".*~b").unwrap();
         let expanded = expand_word_boundaries(&tree).unwrap();
         // .* can match word chars, so at least one branch constrains the dot
@@ -2772,7 +2782,7 @@ mod tests {
     #[test]
     fn test_wb_at_start_single_optional_suffix() {
         // `~b` at value start followed by a single optional atom (`a*`) is the
-        // minimal SplitOrAbsent case: the suffix has exactly one element.
+        // minimal absent case: the suffix has exactly one element.
         let tree = parse("~ba*").unwrap();
         let expanded = expand_word_boundaries(&tree).unwrap();
         assert!(!expanded.is_empty(), "~ba* should expand");
@@ -2795,16 +2805,16 @@ mod tests {
 
     #[test]
     fn test_wb_at_end_split_fallback_uses_previous_atom() {
-        // In ` a*~b` the prefix is [' ', a*] and a* is SplitOrAbsent. When a*
-        // is absent the boundary lands after the space, a non-word char, so
-        // constraining the atom before a* adds no fallback branch — the
-        // fallback considers the previous atom, not a* itself.
+        // In ` a*~b` the prefix is [' ', a*] and a* can be absent. When it is,
+        // the boundary lands after the space — a non-word char, same class as
+        // the closing `"` — so the absent case contributes no branch and only
+        // the present case survives.
         let tree = parse(" a*~b").unwrap();
         let expanded = expand_word_boundaries(&tree).unwrap();
         assert_eq!(
             expanded.len(),
             1,
-            "space is non-word so the SplitOrAbsent fallback adds nothing; got {expanded:?}"
+            "space is non-word so the absent case adds nothing; got {expanded:?}"
         );
     }
 
@@ -2829,5 +2839,62 @@ mod tests {
         };
         assert_eq!(base.cache_key.as_deref(), Some("wb_test"));
         assert_eq!(base.ascii_negated_bytes, Some(vec![b'q']));
+    }
+
+    #[test]
+    fn test_constrain_zero_quantifier_atom_is_absent() {
+        // A `{0}` atom matches nothing, so it is reported as absent whatever
+        // class it is asked for — including one its runes cannot satisfy, and
+        // including a group, which otherwise cannot be constrained at all.
+        for atom in [
+            QuantifiedAtom {
+                runes: vec![RunePair { lo: ' ', hi: ' ' }],
+                quant_min: 0,
+                quant_max: 0,
+                ..Default::default()
+            },
+            QuantifiedAtom {
+                subtree: Some(parse("ab").unwrap()),
+                quant_min: 0,
+                quant_max: 0,
+                ..Default::default()
+            },
+        ] {
+            let constrained = constrain_atom_at_boundary(&atom, &word_char_runes(), true)
+                .expect("a {0} atom is always absent, never impossible");
+            assert!(
+                matches!(constrained, ConstrainedAtom::Absent),
+                "{{0}} atom must constrain to Absent"
+            );
+            assert!(
+                expand_constrained(&constrained, true).is_none(),
+                "an absent atom contributes no atoms to the branch"
+            );
+        }
+    }
+
+    // MIRI SKIP RATIONALE: the patterns deliberately expand to a thousand
+    // branches of ~64 atoms each, which is far too much cloning for Miri.
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_wb_expansion_alternatives_capped() {
+        // Optional word chars before the boundary and optional spaces after it,
+        // so every pairing of surviving neighbours is a valid alternative and
+        // the branch count grows with the product of the two runs.
+        let expand = |before: usize, after: usize| {
+            let re = format!("{}~b{}", "a?".repeat(before), " ?".repeat(after));
+            expand_word_boundaries(&parse(&re).unwrap())
+        };
+
+        // Runs of 32 and 31 expand to exactly the cap, which is still built.
+        let expanded = expand(32, 31).expect("an expansion of exactly the cap is allowed");
+        assert_eq!(expanded.len(), MAX_WB_ALTERNATIVES, "cap is inclusive");
+
+        // One more optional atom after the boundary tips it over.
+        let err = expand(32, 32).expect_err("an expansion past the cap must be refused, not built");
+        assert!(
+            err.contains("exceeds") && err.contains("alternatives"),
+            "error should name the alternatives cap, got {err:?}"
+        );
     }
 }

--- a/src/tests_operators.rs
+++ b/src/tests_operators.rs
@@ -1608,7 +1608,8 @@ fn test_wb_with_dot() {
 
 #[test]
 fn test_wb_plus_quantifier() {
-    // a+~b exercises the Split path (quant_min=1), not SplitOrAbsent
+    // a+~b splits one occurrence off a run that must match at least once, so
+    // there is no branch where the atom is absent
     let q = q!("test" => r#"{"v": [{"regexp": "a+~b "}]}"#);
     assert_has_match!(q, r#"{"v": "aaa "}"#, "test");
     assert_has_match!(q, r#"{"v": "a "}"#, "test");
@@ -1617,10 +1618,11 @@ fn test_wb_plus_quantifier() {
 
 #[test]
 fn test_wb_optional_quantifier() {
-    // a?~b exercises SplitOrAbsent (quant_min=0): when a? pattern_ids 'a',
-    // the boundary is between 'a' (word) and ' ' (non-word)
+    // a? can match zero chars, so xa?~b has two ways to satisfy the boundary:
+    // 'a' (word) before ' ' (non-word), or a absent and 'x' before ' '.
     let q = q!("test" => r#"{"v": [{"regexp": "xa?~b "}]}"#);
     assert_has_match!(q, r#"{"v": "xa "}"#, "test");
+    assert_has_match!(q, r#"{"v": "x "}"#, "test");
     assert_no_has_match!(q, r#"{"v": "xab"}"#, "test");
 }
 
@@ -1631,6 +1633,92 @@ fn test_wb_range_quantifier() {
     assert_has_match!(q, r#"{"v": "aa "}"#, "test");
     assert_has_match!(q, r#"{"v": "aaaa "}"#, "test");
     assert_no_has_match!(q, r#"{"v": "a "}"#, "test");
+}
+
+#[test]
+fn test_wb_zero_quantifier_falls_back_to_previous_atom() {
+    // a{0} can never appear, so the boundary applies against whatever precedes
+    // it — here 'x' (word) against ' ' (non-word), i.e. the pattern is x~b .
+    let q = q!("test" => r#"{"v": [{"regexp": "xa{0}~b "}]}"#);
+    assert_has_match!(q, r#"{"v": "x "}"#, "test");
+    assert_no_has_match!(q, r#"{"v": "xa "}"#, "test");
+    assert_no_has_match!(q, r#"{"v": "x"}"#, "test");
+}
+
+#[test]
+fn test_wb_zero_quantifier_without_previous_atom_err() {
+    // With a{0} absent there is nothing before the boundary, leaving ~b between
+    // the start of the value and ' ' — both non-word, so the boundary is
+    // impossible and the pattern is rejected rather than built.
+    let mut q = Quamina::new();
+    assert_add_err!(q, "test", r#"{"v": [{"regexp": "a{0}~b "}]}"#);
+    assert_add_err!(q, "test", r#"{"v": [{"regexp": "[ab]{0,0}~b "}]}"#);
+}
+
+#[test]
+fn test_wb_zero_quantifier_group() {
+    // A group can never be constrained at a boundary, but (ab){0} never matches
+    // at all, so the boundary resolves against 'x' with the group contributing
+    // nothing — no characters of it may appear in the value.
+    let q = q!("test" => r#"{"v": [{"regexp": "x(ab){0}~b "}]}"#);
+    assert_has_match!(q, r#"{"v": "x "}"#, "test");
+    assert_no_has_match!(q, r#"{"v": "xab "}"#, "test");
+}
+
+#[test]
+fn test_wb_optional_group_rejected() {
+    // (ab)? can match, and a group's characters cannot be intersected with a
+    // word class, so the case where it is present has no expansion. Rejecting
+    // the pattern is honest; expanding only the absent case would silently
+    // match a subset.
+    let mut q = Quamina::new();
+    assert_add_err!(q, "test", r#"{"v": [{"regexp": "x(ab)?~b "}]}"#);
+}
+
+#[test]
+fn test_wb_optional_run_before_boundary() {
+    // Each trailing optional can be present or absent independently, so the
+    // boundary is satisfied by whichever atom ends up last: 'b', 'a' or 'x'.
+    let q = q!("test" => r#"{"v": [{"regexp": "xa?b?~b "}]}"#);
+    assert_has_match!(q, r#"{"v": "xab "}"#, "test");
+    assert_has_match!(q, r#"{"v": "xa "}"#, "test");
+    assert_has_match!(q, r#"{"v": "xb "}"#, "test");
+    assert_has_match!(q, r#"{"v": "x "}"#, "test");
+    assert_no_has_match!(q, r#"{"v": "xab"}"#, "test");
+}
+
+#[test]
+fn test_wb_optional_absent_at_value_start() {
+    // With `_?` absent the boundary sits at value start, where the opening `"`
+    // is non-word, so the following word char satisfies it. Present, `_` is
+    // itself a word char and the boundary is impossible.
+    let q = q!("test" => r#"{"v": [{"regexp": "_?~b~w"}]}"#);
+    assert_has_match!(q, r#"{"v": "a"}"#, "test");
+    assert_no_has_match!(q, r#"{"v": "_a"}"#, "test");
+}
+
+#[test]
+fn test_wb_non_boundary_with_optional_absent() {
+    // ~B needs both sides in the same class. With a* absent, 'x' and 'y' are
+    // both word chars and the non-boundary holds; a space between them would
+    // make it a real boundary instead.
+    let q = q!("test" => r#"{"v": [{"regexp": "xa*~By"}]}"#);
+    assert_has_match!(q, r#"{"v": "xy"}"#, "test");
+    assert_has_match!(q, r#"{"v": "xay"}"#, "test");
+    assert_no_has_match!(q, r#"{"v": "x y"}"#, "test");
+}
+
+#[test]
+fn test_wb_optional_absent_leaves_empty_value() {
+    // Once `a?` is absent the boundary sits between the two `"` delimiters,
+    // both non-word: never a boundary, always a non-boundary.
+    let q = q!("test" => r#"{"v": [{"regexp": "a?~B"}]}"#);
+    assert_has_match!(q, r#"{"v": ""}"#, "test");
+    assert_no_has_match!(q, r#"{"v": "a"}"#, "test");
+
+    let q = q!("test" => r#"{"v": [{"regexp": "a?~b"}]}"#);
+    assert_has_match!(q, r#"{"v": "a"}"#, "test");
+    assert_no_has_match!(q, r#"{"v": ""}"#, "test");
 }
 
 #[test]


### PR DESCRIPTION
`a{0}~b ` panicked in `add_pattern`. Constraining the atom next to a word boundary splits one occurrence off it, and for a `{0}` atom that left a `quant_max` of -1, which blew up the `usize` conversion in the NFA builder. A `{0}` atom matches nothing at all, so it now constrains to a new `Absent` result and the boundary resolves against its neighbour instead.

That neighbour fallback already existed for `?` and `*`, but it only ever looked at the value edge: when the optional atom vanished it assumed the boundary sat against the opening or closing `"`, ignoring any atom still standing between them. So `xa?~b ` never matched `x `, even though dropping `a` leaves `x` (word) against ` ` (non-word). Both sides of a boundary now walk outwards over atoms that can be absent, which subsumes the two one-level fallbacks and gives every combination of present and absent neighbours its own branch. `x(ab){0}~b ` works too; an optional group next to a boundary is still rejected, since only its absent case could be expanded and matching that alone would silently drop the other half of the pattern.

Walking both sides multiplies branches — 32 optional atoms either side of a boundary is a thousand of them — so the expansion is capped at 1024 alternatives and patterns past it are refused rather than materialized. Real patterns are nowhere near: the widest one in the test suite expands to two.

The sweep over `REGEXP_SAMPLES` skips every `~b`/`~B` sample, so the new coverage is hand-written: the two pinned reproducers plus optional runs, groups, `~B`, the value-start and empty-value cases, and the cap's exact boundary.

Also corrects two comments claiming `a{0,}` and `a{1,}` are capped at `REGEXP_QUANTIFIER_MAX`. Both build the same cyclic loop as `a*` and `a+`, which never reads `quant_max`.

`cargo test`: 950 pass. Clippy clean, mutation gate clean, and the new tests add ~11s under Miri with the cap test skipped there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)