### PR TITLE
fix: walk long automaton chains without recursing per state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Style inspired by [ripgrep's CHANGELOG](https://github.com/BurntSushi/ripgrep/bl
 - Removed the runtime memory-budget API (`get_memory_budget`/`set_memory_budget`), matching Go upstream dropping it; the build-time `QuaminaBuilder::with_arena_byte_budget` cap remains (#152)
 
 ### Fixed
+- Long single-chain patterns no longer overflow the stack and abort the process — a 5,000-character `prefix` on a 2 MB thread used to die at freeze — because the arena walks that build, fold and clone a chain now carry their own stack instead of recursing once per state (#189)
 - Lookaround regexps now match against the value itself, not just their assertions: `foo(?!bar)baz` no longer matches `totally-unrelated`, `(?=.*foo).*bar.*` matches `foobar`, and `(?<=foo)bar(?=baz)baz` matches `foobarbaz` (#182, #183, #184)
 - `BuiltForSpeed` now holds its freeze-time DFA to the arena byte budget, keeping the NFA when there is no room, and applies to lookaround regexps, which it used to leave as NFAs (#186, #188)
 - `matcher_stats()` and `arena_stats()` now count the lazy DFA cache a `BuiltForSpeed` pattern falls back to, and the cache no longer allocates a transition table for states it declines to cache (#185, #186)

--- a/src/automaton/arena.rs
+++ b/src/automaton/arena.rs
@@ -2022,60 +2022,81 @@ pub(crate) fn clone_arena_subset(arena: &StateArena, start: StateId) -> (StateAr
     let mut new_arena = StateArena::new();
     let mut id_map: FxHashMap<u32, StateId> = FxHashMap::default();
 
-    clone_state_recursive(arena, start, &mut new_arena, &mut id_map);
-
-    let new_start = id_map.get(&start.0).copied().unwrap_or(StateId::NONE);
+    let new_start = clone_states_into_arena(arena, start, &mut new_arena, &mut id_map);
     new_arena.precompute_epsilon_closures();
     (new_arena, new_start)
 }
 
-/// Recursively clone a state and its descendants.
-fn clone_state_recursive(
-    arena: &StateArena,
-    state_id: StateId,
-    new_arena: &mut StateArena,
+/// Clone `start` and everything reachable from it into `target`, recording
+/// old-to-new ids in `id_map` and returning the new id of `start`.
+///
+/// An entry already in `id_map` is left alone, so several starts can be cloned
+/// into one arena and keep sharing whatever they share.
+///
+/// The walk carries its own stack rather than recursing per state. A prefix,
+/// exact-match or shellstyle pattern is one state per byte, so the graph is as
+/// deep as the pattern is long — deep enough that recursion runs a small thread
+/// out of stack, which aborts the process instead of raising an error anyone
+/// could handle.
+fn clone_states_into_arena(
+    source: &StateArena,
+    start: StateId,
+    target: &mut StateArena,
     id_map: &mut FxHashMap<u32, StateId>,
 ) -> StateId {
-    if state_id.is_none() {
+    if start.is_none() {
         return StateId::NONE;
     }
 
-    // Check if already cloned
-    if let Some(&new_id) = id_map.get(&state_id.0) {
-        return new_id;
+    // Allocate every state the walk reaches, in the order it reaches them.
+    // Tables are remapped afterwards, by which point every state they point at
+    // has an id — including their own, so cycles need no special handling.
+    //
+    // Both scratch buffers are bounded by the source arena, and taking that
+    // much up front keeps their growth from interleaving with the states being
+    // allocated, which scatters the cloned automaton across the heap.
+    let mut cloned: Vec<(StateId, StateId)> = Vec::with_capacity(source.len());
+    let mut pending = Vec::with_capacity(source.len());
+    pending.push(start);
+    while let Some(old_id) = pending.pop() {
+        if old_id.is_none() || id_map.contains_key(&old_id.0) {
+            continue;
+        }
+
+        let new_id = target.alloc();
+        id_map.insert(old_id.0, new_id);
+        cloned.push((old_id, new_id));
+
+        // Reversed, so that popping visits the table in its own order.
+        let table = &source[old_id].table;
+        pending.extend(table.steps.iter().chain(&table.epsilons).rev().copied());
     }
 
-    // Allocate new state first (to handle cycles)
-    let new_id = new_arena.alloc();
-    id_map.insert(state_id.0, new_id);
+    let remap = |id: &StateId| id_map.get(&id.0).copied().unwrap_or(StateId::NONE);
+    for (old_id, new_id) in cloned {
+        let old_state = &source[old_id];
+        let old_table = &old_state.table;
+        // Sized up front: collecting would round the capacity up and leave the
+        // clone holding more than the arena it came from.
+        let mut steps = SmallVec::with_capacity(old_table.steps.len());
+        steps.extend(old_table.steps.iter().map(remap));
+        let mut epsilons = SmallVec::with_capacity(old_table.epsilons.len());
+        epsilons.extend(old_table.epsilons.iter().map(remap));
+        let new_table = SmallTable {
+            ceilings: old_table.ceilings.clone(),
+            steps,
+            epsilons,
+            accel: old_table.accel.clone(),
+        };
+        // Field transitions are cold data; the Arc clone is cheap.
+        let field_transitions = old_state.field_transitions.clone();
 
-    // Clone field transitions (Arc clone is cheap) - cold data
-    new_arena[new_id].field_transitions = arena[state_id].field_transitions.clone();
-
-    let old_state = &arena[state_id];
-
-    // Clone table with remapped state IDs
-    let old_table = &old_state.table;
-    let mut new_table = SmallTable {
-        ceilings: old_table.ceilings.clone(),
-        steps: SmallVec::with_capacity(old_table.steps.len()),
-        epsilons: SmallVec::with_capacity(old_table.epsilons.len()),
-        accel: old_table.accel.clone(),
-    };
-
-    for &step_id in &old_table.steps {
-        let new_step = clone_state_recursive(arena, step_id, new_arena, id_map);
-        new_table.steps.push(new_step);
+        let new_state = &mut target[new_id];
+        new_state.table = new_table;
+        new_state.field_transitions = field_transitions;
     }
 
-    for &eps_id in &old_table.epsilons {
-        let new_eps = clone_state_recursive(arena, eps_id, new_arena, id_map);
-        new_table.epsilons.push(new_eps);
-    }
-
-    new_arena[new_id].table = new_table;
-
-    new_id
+    id_map.get(&start.0).copied().unwrap_or(StateId::NONE)
 }
 
 /// Recursively merge two states from different arenas.
@@ -2309,12 +2330,36 @@ pub(crate) fn determinize_branch_starts(
 
 /// Merge two alternation branch states within a single arena. `boundary` is the
 /// shared continuation, treated as an opaque leaf (never baked or collapsed).
+///
+/// A pair's merged state is allocated as soon as the pair is reached and filled
+/// in from a queue afterwards, rather than while descending into it. A branch is
+/// one state per byte, so descending would put a stack frame on every byte of
+/// the longest branch.
 fn merge_branch_pair(
     arena: &mut StateArena,
     a: StateId,
     b: StateId,
     boundary: StateId,
     memo: &mut FxHashMap<(StateId, StateId), StateId>,
+) -> StateId {
+    let mut pending: Vec<(StateId, StateId, StateId)> = Vec::new();
+    let start = resolve_branch_pair(arena, a, b, memo, &mut pending);
+
+    while let Some((a, b, new_id)) = pending.pop() {
+        fill_merged_branch_state(arena, a, b, new_id, boundary, memo, &mut pending);
+    }
+
+    start
+}
+
+/// The state a pair of branch states merges into, allocating and queueing it
+/// the first time the pair is seen.
+fn resolve_branch_pair(
+    arena: &mut StateArena,
+    a: StateId,
+    b: StateId,
+    memo: &mut FxHashMap<(StateId, StateId), StateId>,
+    pending: &mut Vec<(StateId, StateId, StateId)>,
 ) -> StateId {
     // Converging branches share their state directly; no new node is allocated.
     if a == b {
@@ -2330,16 +2375,29 @@ fn merge_branch_pair(
         return cached;
     }
 
+    // Record the memo entry before queueing so byte cycles terminate.
+    let new_id = arena.alloc();
+    memo.insert((a, b), new_id);
+    pending.push((a, b, new_id));
+    new_id
+}
+
+/// Fill in the state `a` and `b` merge into, queueing the pairs it reaches.
+fn fill_merged_branch_state(
+    arena: &mut StateArena,
+    a: StateId,
+    b: StateId,
+    new_id: StateId,
+    boundary: StateId,
+    memo: &mut FxHashMap<(StateId, StateId), StateId>,
+    pending: &mut Vec<(StateId, StateId, StateId)>,
+) {
     // Epsilon-led entries (a quantifier loop) and the boundary cannot be
     // byte-merged; they are joined behind an epsilon splice instead.
     let needs_splice = !arena[a].table.epsilons.is_empty()
         || !arena[b].table.epsilons.is_empty()
         || a == boundary
         || b == boundary;
-
-    // Insert the memo entry before recursing so byte cycles terminate.
-    let new_id = arena.alloc();
-    memo.insert((a, b), new_id);
 
     if needs_splice {
         // The new state's epsilons are the two entries' real targets, so both
@@ -2354,7 +2412,7 @@ fn merge_branch_pair(
             epsilons: targets,
             accel: None,
         };
-        return new_id;
+        return;
     }
 
     // Byte-wise merge: for each byte value, merge the pair of target states.
@@ -2368,12 +2426,11 @@ fn merge_branch_pair(
 
     let mut merged = [StateId::NONE; BYTE_CEILING];
     for i in 0..BYTE_CEILING {
-        merged[i] = merge_branch_pair(arena, unpacked_a[i], unpacked_b[i], boundary, memo);
+        merged[i] = resolve_branch_pair(arena, unpacked_a[i], unpacked_b[i], memo, pending);
     }
 
     arena[new_id].field_transitions = field_transitions;
     arena[new_id].table.pack(&merged);
-    new_id
 }
 
 /// Collect the real (non-epsilon-only) targets reachable from `state` through
@@ -2391,15 +2448,19 @@ fn collect_branch_epsilon_targets(
     visited: &mut FxHashSet<u32>,
     out: &mut SmallVec<[StateId; 2]>,
 ) {
-    if state.is_none() || !visited.insert(state.0) {
-        return;
-    }
-    if state != boundary && is_epsilon_only_state(arena, state) {
-        for &eps in &arena[state].table.epsilons {
-            collect_branch_epsilon_targets(arena, eps, boundary, visited, out);
+    // Splices chain as far as the merges that built them, so this walk keeps
+    // its own stack rather than recursing through the chain.
+    let mut pending = vec![state];
+    while let Some(state) = pending.pop() {
+        if state.is_none() || !visited.insert(state.0) {
+            continue;
         }
-    } else {
-        out.push(state);
+        if state != boundary && is_epsilon_only_state(arena, state) {
+            // Reversed, so popping walks the splice's targets in their order.
+            pending.extend(arena[state].table.epsilons.iter().rev().copied());
+        } else {
+            out.push(state);
+        }
     }
 }
 
@@ -3089,8 +3150,8 @@ fn merge_arena_nfa_states_recursive(
     if s1_has_epsilons || s2_has_epsilons {
         let mut clone_map1: FxHashMap<u32, StateId> = FxHashMap::default();
         let mut clone_map2: FxHashMap<u32, StateId> = FxHashMap::default();
-        let cloned1 = clone_state_into_arena(arena1, state1, new_arena, &mut clone_map1);
-        let cloned2 = clone_state_into_arena(arena2, state2, new_arena, &mut clone_map2);
+        let cloned1 = clone_states_into_arena(arena1, state1, new_arena, &mut clone_map1);
+        let cloned2 = clone_states_into_arena(arena2, state2, new_arena, &mut clone_map2);
 
         // Flatten: if cloned states are themselves epsilon-only splices,
         // collect their real targets directly instead of nesting splices.
@@ -3358,58 +3419,6 @@ fn merge_asymmetric_spinner_byte(
         new_arena[merged_branch].table.epsilons.push(new_id);
     }
     merged_branch
-}
-
-/// Clone a state and all its reachable states from source arena into target arena.
-///
-/// Uses a separate id_map to track old->new state mappings, allowing multiple
-/// independent clones from different arenas without memo key conflicts.
-fn clone_state_into_arena(
-    source_arena: &StateArena,
-    state_id: StateId,
-    target_arena: &mut StateArena,
-    id_map: &mut FxHashMap<u32, StateId>,
-) -> StateId {
-    if state_id.is_none() {
-        return StateId::NONE;
-    }
-
-    // Check if already cloned
-    if let Some(&new_id) = id_map.get(&state_id.0) {
-        return new_id;
-    }
-
-    // Allocate new state first (to handle cycles)
-    let new_id = target_arena.alloc();
-    id_map.insert(state_id.0, new_id);
-
-    // Clone field transitions (Arc clone is cheap) - cold data
-    target_arena[new_id].field_transitions = source_arena[state_id].field_transitions.clone();
-
-    let old_state = &source_arena[state_id];
-
-    // Clone table with remapped state IDs
-    let old_table = &old_state.table;
-    let mut new_table = SmallTable {
-        ceilings: old_table.ceilings.clone(),
-        steps: SmallVec::with_capacity(old_table.steps.len()),
-        epsilons: SmallVec::with_capacity(old_table.epsilons.len()),
-        accel: old_table.accel.clone(),
-    };
-
-    for &step_id in &old_table.steps {
-        let new_step = clone_state_into_arena(source_arena, step_id, target_arena, id_map);
-        new_table.steps.push(new_step);
-    }
-
-    for &eps_id in &old_table.epsilons {
-        let new_eps = clone_state_into_arena(source_arena, eps_id, target_arena, id_map);
-        new_table.epsilons.push(new_eps);
-    }
-
-    target_arena[new_id].table = new_table;
-
-    new_id
 }
 
 /// Remap a table from source arena to the merged arena (NFA version).
@@ -3873,36 +3882,34 @@ pub fn make_string_arena_fa(val: &[u8], next_field: Arc<FieldMatcher>) -> (State
     arena[match_state].field_transitions.push(next_field);
 
     // Build the FA chain from end to start
-    let start = make_string_arena_fa_step(val, 0, match_state, &mut arena);
+    let start = make_string_arena_fa_step(val, match_state, &mut arena);
 
     arena.precompute_epsilon_closures();
     (arena, start)
 }
 
-/// Recursive helper for building string-matching FA.
-fn make_string_arena_fa_step(
-    val: &[u8],
-    index: usize,
-    match_state: StateId,
-    arena: &mut StateArena,
-) -> StateId {
-    if index >= val.len() {
-        // Final step: transition on VALUE_TERMINATOR to match state
-        return arena.alloc_with_table(SmallTable::with_mappings(
+/// Build the chain of one state per byte of `val`, ending in a state that
+/// reaches `match_state` on the value terminator, and return its first state.
+///
+/// Built back to front, so each state can point at the one already built. The
+/// chain is as long as the value, which is why this is a loop: a recursive
+/// build would put a stack frame on every byte of it.
+fn make_string_arena_fa_step(val: &[u8], match_state: StateId, arena: &mut StateArena) -> StateId {
+    let mut current = arena.alloc_with_table(SmallTable::with_mappings(
+        StateId::NONE,
+        &[ARENA_VALUE_TERMINATOR],
+        &[match_state],
+    ));
+
+    for &byte in val.iter().rev() {
+        current = arena.alloc_with_table(SmallTable::with_mappings(
             StateId::NONE,
-            &[ARENA_VALUE_TERMINATOR],
-            &[match_state],
+            &[byte],
+            &[current],
         ));
     }
 
-    // Recursive step: build rest of chain first, then prepend current byte
-    let continuation = make_string_arena_fa_step(val, index + 1, match_state, arena);
-
-    arena.alloc_with_table(SmallTable::with_mappings(
-        StateId::NONE,
-        &[val[index]],
-        &[continuation],
-    ))
+    current
 }
 
 /// Rollback data for an in-place trie insertion.
@@ -4099,37 +4106,36 @@ pub fn make_prefix_arena_fa(prefix: &[u8], next_field: Arc<FieldMatcher>) -> (St
     arena[match_state].field_transitions.push(next_field);
 
     // Build the FA chain from end to start
-    let start = make_prefix_arena_fa_step(prefix, 0, match_state, &mut arena);
+    let start = make_prefix_arena_fa_step(prefix, match_state, &mut arena);
 
     arena.precompute_epsilon_closures();
     (arena, start)
 }
 
-/// Recursive helper for building prefix-matching FA.
+/// Build the chain of one state per byte of `prefix`, ending in a state that
+/// reaches `match_state` on any byte, and return its first state.
+///
+/// Built back to front, so each state can point at the one already built. The
+/// chain is as long as the prefix, which is why this is a loop: a recursive
+/// build would put a stack frame on every byte of it.
 fn make_prefix_arena_fa_step(
     prefix: &[u8],
-    index: usize,
     match_state: StateId,
     arena: &mut StateArena,
 ) -> StateId {
-    if index >= prefix.len() {
-        // End of prefix: all bytes should transition to match state (default)
-        // Use match_state as default for all byte values
-        return arena.alloc_with_table(SmallTable::with_mappings(
-            match_state, // Default transition for all bytes
-            &[],
-            &[],
+    // Past the prefix everything matches, so the last state takes match_state
+    // as its default transition.
+    let mut current = arena.alloc_with_table(SmallTable::with_mappings(match_state, &[], &[]));
+
+    for &byte in prefix.iter().rev() {
+        current = arena.alloc_with_table(SmallTable::with_mappings(
+            StateId::NONE,
+            &[byte],
+            &[current],
         ));
     }
 
-    // Recursive step: build rest of chain first, then prepend current byte
-    let continuation = make_prefix_arena_fa_step(prefix, index + 1, match_state, arena);
-
-    arena.alloc_with_table(SmallTable::with_mappings(
-        StateId::NONE,
-        &[prefix[index]],
-        &[continuation],
-    ))
+    current
 }
 
 /// Build an arena-based FA that matches shellstyle wildcard patterns.
@@ -4565,8 +4571,7 @@ pub fn make_monocase_arena_fa(val: &[u8], next_field: Arc<FieldMatcher>) -> (Sta
             })
             .collect();
 
-        // Build the FA recursively
-        build_monocase_arena_recursive(&chars, 0, match_state, &mut arena)
+        build_monocase_arena_chain(&chars, match_state, &mut arena)
     } else {
         // Invalid UTF-8 - fall back to ASCII-only case folding
         build_monocase_ascii_chain(val, match_state, &mut arena)
@@ -4619,28 +4624,39 @@ fn build_monocase_ascii_chain(val: &[u8], match_state: StateId, arena: &mut Stat
     current_next
 }
 
-/// Recursively build monocase arena FA
-fn build_monocase_arena_recursive(
+/// Build the monocase arena FA for `chars`, returning its first state.
+///
+/// Built back to front, so each character's states can point at the states of
+/// the character after it. The chain is as long as the string, which is why
+/// this is a loop: a recursive build would put a stack frame on every
+/// character of it.
+fn build_monocase_arena_chain(
     chars: &[(Vec<u8>, Option<Vec<u8>>)],
-    idx: usize,
     match_state: StateId,
     arena: &mut StateArena,
 ) -> StateId {
-    if idx >= chars.len() {
-        // End of string - create state that matches on VALUE_TERMINATOR
-        return arena.alloc_with_table(SmallTable::with_mappings(
-            StateId::NONE,
-            &[ARENA_VALUE_TERMINATOR],
-            &[match_state],
-        ));
+    // End of string - create state that matches on VALUE_TERMINATOR
+    let mut next_state = arena.alloc_with_table(SmallTable::with_mappings(
+        StateId::NONE,
+        &[ARENA_VALUE_TERMINATOR],
+        &[match_state],
+    ));
+
+    for (orig, alt) in chars.iter().rev() {
+        next_state = build_monocase_char(orig, alt.as_deref(), next_state, arena);
     }
 
-    let (orig, alt) = &chars[idx];
+    next_state
+}
 
-    // First, build the state for after this character
-    let next_state = build_monocase_arena_recursive(chars, idx + 1, match_state, arena);
-
-    // Now build the transition(s) for this character
+/// Build the states matching one character — either case of it, where the two
+/// cases differ — all of them reaching `next_state`.
+fn build_monocase_char(
+    orig: &[u8],
+    alt: Option<&[u8]>,
+    next_state: StateId,
+    arena: &mut StateArena,
+) -> StateId {
     if let Some(alt_bytes) = alt {
         // Two paths to next state - handle common prefix
         let common_prefix = orig

--- a/tests/deep_chain_stack.rs
+++ b/tests/deep_chain_stack.rs
@@ -1,0 +1,100 @@
+//! Long single-chain patterns must survive being built and frozen on a small
+//! stack. A `prefix` pattern allocates one state per byte, and the arena walks
+//! that build, fold and clone that chain visit it one state at a time, so their
+//! depth tracks the pattern length rather than anything the memory budget can
+//! see.
+//!
+//! Overflowing a stack aborts the process instead of raising a catchable panic,
+//! which would take the whole test binary down with it. The reproducer
+//! therefore runs in a child process — the parent re-executes this same test
+//! binary with `GUARD` set and asserts only on the child's exit status.
+
+use std::process::Command;
+
+use quamina::Quamina;
+
+/// Set in the child process to select the reproducer instead of the spawner.
+const GUARD: &str = "QUAMINA_DEEP_CHAIN_CHILD";
+
+/// One arena state per byte, so this is also the chain depth.
+const CHAIN_LEN: usize = 5_000;
+
+/// The walks that lay a chain down held out further than the one that cloned
+/// it, so their cases need a longer chain before the stack runs out.
+const LONG_CHAIN_LEN: usize = 20_000;
+
+/// Tokio's default worker stack, i.e. the smallest stack a caller is likely to
+/// reach this code on.
+const STACK_BYTES: usize = 2 * 1024 * 1024;
+
+#[test]
+#[cfg_attr(miri, ignore = "spawns a child process")]
+fn deep_prefix_chain_survives_small_stack() {
+    if std::env::var_os(GUARD).is_some() {
+        build_and_match_deep_chain();
+        return;
+    }
+
+    let exe = std::env::current_exe().expect("path to this test binary");
+    let status = Command::new(exe)
+        .args([
+            "deep_prefix_chain_survives_small_stack",
+            "--exact",
+            "--nocapture",
+        ])
+        .env(GUARD, "1")
+        .status()
+        .expect("spawn the reproducer in a child process");
+
+    assert!(
+        status.success(),
+        "child process building a {CHAIN_LEN}-state chain on a {STACK_BYTES}-byte stack exited with {status}"
+    );
+}
+
+fn build_and_match_deep_chain() {
+    let worker = std::thread::Builder::new()
+        .stack_size(STACK_BYTES)
+        .spawn(|| {
+            let value = "x".repeat(CHAIN_LEN);
+            let mut q = Quamina::new();
+            q.add_pattern("chain", &format!(r#"{{"f": [{{"prefix": "{value}"}}]}}"#))
+                .expect("a chain this long is well inside the arena byte budget");
+
+            let event = format!(r#"{{"f": "{value}tail"}}"#);
+            let matches = q
+                .matches_for_event(event.as_bytes())
+                .expect("matching against the frozen chain");
+            assert_eq!(matches, vec!["chain"]);
+
+            // Every pattern type that compiles to a chain reaches a different
+            // walk over it: the exact-match and case-folded builders lay the
+            // chain down, and an alternation folds two of them together.
+            let long = "x".repeat(LONG_CHAIN_LEN);
+            match_deep_pattern(&format!(r#"{{"f": ["{long}"]}}"#), &long);
+            match_deep_pattern(
+                &format!(r#"{{"f": [{{"equals-ignore-case": "{long}"}}]}}"#),
+                &long,
+            );
+            match_deep_pattern(
+                &format!(r#"{{"f": [{{"regexp": "{long}|{long}z"}}]}}"#),
+                &long,
+            );
+        })
+        .expect("spawn the fixed-stack worker thread");
+
+    worker.join().expect("worker thread panicked");
+}
+
+/// Add one deep pattern and match the value it was built from.
+fn match_deep_pattern(pattern: &str, value: &str) {
+    let mut q = Quamina::new();
+    q.add_pattern("chain", pattern)
+        .expect("a chain this long is well inside the arena byte budget");
+
+    let event = format!(r#"{{"f": "{value}"}}"#);
+    let matches = q
+        .matches_for_event(event.as_bytes())
+        .expect("matching against the frozen chain");
+    assert_eq!(matches, vec!["chain"], "pattern: {pattern:.40}…");
+}


### PR DESCRIPTION
A pattern that compiles to a chain — `prefix`, exact match, shellstyle, `equals-ignore-case` — is one arena state per byte, and every walk over that chain recursed once per state. A 5,000-character prefix on a 2 MB thread ran the stack out at freeze. That aborts the process instead of raising anything a caller could handle, and the arena byte budget cannot see it coming: the cost is stack, not heap.

The clone walk now allocates the states it reaches from an explicit worklist and remaps their tables in a second pass, visiting them in the same order the recursion did. The three builders that lay a chain down do it back to front in a loop. The alternation fold allocates each merged pair as it reaches it and fills the state in from a queue, which it can do because it only ever inspects the two states going in, never the merged state coming out. `clone_state_recursive` and `clone_state_into_arena` were the same function written twice, so they are now one.

Two walks of the same shape are left recursive, both measured on a 2 MB stack: the chain merge (`append_merge_nfa_states_recursive`) aborts on two 5,000-character prefixes, and the anything-but trie aborts on a 5,000-character value. The merge is not a mechanical conversion — it reads a merged child's table back while building the parent, to decide whether to flatten an epsilon splice, so deferring the fill changes what it sees. That wants its own change and its own benchmarks rather than riding along here.

Benchmarks, pre-built and interleaved four times each: `100_prefix_patterns` 131 → 119 ns and `regexp_plus_long` 657 → 641 ns, `pathological_epsilon`, `shellstyle_26_patterns`, `shellstyle_multi_match` and the add-pattern scaling benches all unmoved. The clone's scratch buffers are sized up front on purpose — letting them grow while the arena grows interleaves the two, and the frozen automaton lands scattered enough to cost ~10% on `shellstyle_26_patterns`.

The reproducer runs in a child process, since an overflow would otherwise take the test binary with it. It covers the prefix chain that reported the bug plus one case per builder and the alternation fold.

`cargo test`: 940 lib tests pass. Clippy and the mutation gate are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)