### PR TITLE
chore: improve crate metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,11 +3,11 @@ name = "quamina"
 version = "0.7.0"
 edition = "2024"
 rust-version = "1.88"
-description = "Fast pattern-matching library for filtering JSON events"
+description = "Microsecond multi-pattern JSON event filtering and routing engine for high-throughput cloud services and event streams"
 license = "Apache-2.0"
 repository = "https://github.com/baldawarishi/quamina-rs"
-keywords = ["json", "pattern-matching", "event-filtering", "rules-engine"]
-categories = ["algorithms", "text-processing"]
+keywords = ["json", "pattern-matching", "event-filtering", "rules-engine", "stream-processing"]
+categories = ["algorithms", "text-processing", "parser-implementations", "data-structures"]
 exclude = ["testdata/", "docs/", "examples/", "benches/", "fuzz/", "playground/", ".github/", "scripts/"]
 
 [dependencies]


### PR DESCRIPTION
## Summary

- describe Quamina as a microsecond multi-pattern JSON event filtering and routing engine
- retain the existing capability-based keywords and add stream-processing
- expand the applicable crates.io categories

## Metadata choices

- Keep the keyword list to crates.io’s five-keyword maximum.
- Avoid branded platform keywords or compatibility claims; the metadata describes what the crate does rather than naming systems it may be used with.
- Avoid a blanket “zero-allocation” claim because the public matching API returns a Vec and may allocate.
- Omit the asynchronous category because Quamina currently exposes synchronous APIs.

## Validation

- cargo package --allow-dirty
- cargo test --lib (918 passed)
- cargo clippy --all-targets --all-features -- -D warnings
- cargo fmt -- --check