### PR TITLE
chore: satisfy clippy 1.98 lints

### DIFF
--- a/src/automaton/arena.rs
+++ b/src/automaton/arena.rs
@@ -5974,7 +5974,7 @@ mod tests {
 
         // With 3 exit bytes
         table.accel = Some(super::super::AccelInfo {
-            exit_bytes: [b'x', b'y', b'z'],
+            exit_bytes: *b"xyz",
             len: 3,
         });
         assert_eq!(try_accelerate_arena(&table, b"abcdefghijz"), Some(nz(10))); // finds 'z' at position 10
@@ -7006,7 +7006,7 @@ mod merge_tests {
         let mut bufs1 = NfaBuffers::with_capacity();
         let mut bufs2 = NfaBuffers::with_capacity();
 
-        for byte in [b'a', b'b', b'c'] {
+        for byte in *b"abc" {
             bufs1.clear();
             bufs2.clear();
             traverse_arena_nfa(&abc_left, abc_left_start, &[byte], &mut bufs1);

--- a/src/flatten_json.rs
+++ b/src/flatten_json.rs
@@ -221,20 +221,20 @@ const fn should_capture_value(skipping: i32, member_is_used: bool) -> bool {
 
 /// Returns true when `event[index]` exists AND is an ASCII digit.
 #[inline]
-fn at_digit(event: &[u8], index: usize) -> bool {
+const fn at_digit(event: &[u8], index: usize) -> bool {
     index < event.len() && event[index].is_ascii_digit()
 }
 
 /// Returns true when `event[index]` exists AND matches `target`.
 #[inline]
-fn at_byte(event: &[u8], index: usize, target: u8) -> bool {
+const fn at_byte(event: &[u8], index: usize, target: u8) -> bool {
     index < event.len() && event[index] == target
 }
 
 /// Returns true when `event[index..]` starts with a `\uXXXX` escape (six
 /// bytes: backslash, `u`, four hex digits).
 #[inline]
-fn has_unicode_escape_at(event: &[u8], index: usize) -> bool {
+const fn has_unicode_escape_at(event: &[u8], index: usize) -> bool {
     index + 5 < event.len() && event[index] == b'\\' && event[index + 1] == b'u'
 }
 
@@ -1025,7 +1025,7 @@ impl<'a> FlattenContext<'a, '_> {
 
     /// Get current byte.
     #[inline]
-    fn ch(&self) -> u8 {
+    const fn ch(&self) -> u8 {
         self.event[self.index]
     }
 

--- a/src/json.rs
+++ b/src/json.rs
@@ -819,12 +819,16 @@ fn parse_numeric_comparison(arr: &[Value]) -> Option<NumericComparison> {
     let mut lower = None;
     let mut upper = None;
 
-    let mut pairs = arr.chunks_exact(2);
-    for pair in &mut pairs {
-        let Value::String(op) = &pair[0] else {
+    let (pairs, remainder) = arr.as_chunks::<2>();
+    if !remainder.is_empty() {
+        return None;
+    }
+
+    for [op, value] in pairs {
+        let Value::String(op) = op else {
             return None;
         };
-        let num = match &pair[1] {
+        let num = match value {
             Value::Number(n) => n.parse::<f64>().ok()?,
             _ => return None,
         };
@@ -840,9 +844,6 @@ fn parse_numeric_comparison(arr: &[Value]) -> Option<NumericComparison> {
             }
             _ => return None,
         }
-    }
-    if !pairs.remainder().is_empty() {
-        return None;
     }
 
     Some(NumericComparison { lower, upper })


### PR DESCRIPTION
Clippy 1.98 rejects few things that were working before. This fixes them and unblocks the dependabot PRs. 
